### PR TITLE
fix: quote substitutions arg to prevent shell semicolon splitting

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -81,7 +81,5 @@ jobs:
 
       - name: Deploy Cloud Run (dev)
         run: |
-          SUBS="^;^"
-          SUBS+="_SERVICE_NAME=${{ vars.DEV_SERVICE_NAME }};"
-          SUBS+="_REGION=${{ vars.DEV_REGION }}"
-          gcloud builds submit --config=cloudbuild.yaml --substitutions="${SUBS}"
+          gcloud builds submit --config=cloudbuild.yaml \
+            --substitutions="_SERVICE_NAME=giftwiki-dev,_REGION=us-east1"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -75,8 +75,9 @@ jobs:
       - name: Apply Terraform (dev)
         run: |
           make terraform-init ENV=dev
-          cd terraform && terraform workspace select dev
-          cd terraform && terraform apply -auto-approve -var-file="dev.tfvars"
+          cd terraform
+          terraform workspace select dev
+          terraform apply -auto-approve -var-file="dev.tfvars"
 
       - name: Deploy Cloud Run (dev)
         run: |

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -72,5 +72,15 @@ jobs:
             '{"django-secret-key":$dsk,"django-db-user":$dbu,"django-db-password":$dbp,"aws-access-key-id":$aki,"aws-secret-access-key":$ask}')
           echo "TF_VAR_secret_values=$TF_VAR_secret_values" >> $GITHUB_ENV
 
-      - name: Deploy Dev
-        run: make dev
+      - name: Apply Terraform (dev)
+        run: |
+          make terraform-init ENV=dev
+          cd terraform && terraform workspace select dev
+          cd terraform && terraform apply -auto-approve -var-file="dev.tfvars"
+
+      - name: Deploy Cloud Run (dev)
+        run: |
+          SUBS="^;^"
+          SUBS+="_SERVICE_NAME=${{ vars.DEV_SERVICE_NAME }};"
+          SUBS+="_REGION=${{ vars.DEV_REGION }}"
+          gcloud builds submit --config=cloudbuild.yaml --substitutions="${SUBS}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,5 +75,21 @@ jobs:
             '{"django-secret-key":$dsk,"django-db-user":$dbu,"django-db-password":$dbp,"aws-access-key-id":$aki,"aws-secret-access-key":$ask}')
           echo "TF_VAR_secret_values=$TF_VAR_secret_values" >> $GITHUB_ENV
 
-      - name: Deploy Production
-        run: make prod
+      - name: Apply Terraform (prod)
+        run: |
+          make terraform-init ENV=prod
+          cd terraform && terraform workspace select prod
+          cd terraform && terraform apply -auto-approve -var-file="prod.tfvars"
+
+      - name: Deploy Cloud Run (prod)
+        run: |
+          SUBS="^;^"
+          SUBS+="_SERVICE_NAME=${{ vars.PROD_SERVICE_NAME }};"
+          SUBS+="_REGION=${{ vars.PROD_REGION }};"
+          SUBS+="_DB_HOST=${{ vars.PROD_DB_HOST }};"
+          SUBS+="_DB_NAME=${{ vars.PROD_DB_NAME }};"
+          SUBS+="_FIREBASE_API_KEY_SECRET=${{ vars.PROD_FIREBASE_API_KEY_SECRET }};"
+          SUBS+="_ALLOWED_USERS_SECRET=${{ vars.PROD_ALLOWED_USERS_SECRET }};"
+          SUBS+="_ALLOWED_HOSTS=${{ vars.PROD_ALLOWED_HOSTS }};"
+          SUBS+="_ALLOWED_ORIGINS=${{ vars.PROD_ALLOWED_ORIGINS }}"
+          gcloud builds submit --config=cloudbuild.yaml --substitutions="${SUBS}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,8 +78,9 @@ jobs:
       - name: Apply Terraform (prod)
         run: |
           make terraform-init ENV=prod
-          cd terraform && terraform workspace select prod
-          cd terraform && terraform apply -auto-approve -var-file="prod.tfvars"
+          cd terraform
+          terraform workspace select prod
+          terraform apply -auto-approve -var-file="prod.tfvars"
 
       - name: Deploy Cloud Run (prod)
         run: |

--- a/Makefile
+++ b/Makefile
@@ -244,25 +244,24 @@ firebase-deploy-prod: firebase-ensure-logged-in
 	@$(FIREBASE) deploy --only hosting:prod
 	@echo "✅ Firebase Functions and Hosting deployed (prod)"
 
-# Deploy to Kubernetes and Cloud Run (Dev) - Full deployment with infrastructure setup
 # Deploy to Cloud Run (Dev)
+# App deployment is handled by GitHub Actions (deploy-dev.yml) using repository variables.
+# To deploy locally, set DEV_* env vars (DEV_SERVICE_NAME, DEV_REGION) and run: make deploy-app-dev
 dev: ENV=dev
 dev:
 	@echo "Step 1: Ensure infrastructure (secrets, IAM, Firebase Auth) with Terraform..."
 	@$(MAKE) terraform-init ENV=dev
 	@cd terraform && terraform workspace select dev
 	@cd terraform && terraform apply -auto-approve -var-file="dev.tfvars"
-	@echo "Step 2: Deploy Cloud Run application (builds image)..."
-	@$(MAKE) cloud-run-deploy-app
-	@echo ""
-	@echo "Getting Cloud Run service URL..."
-	@SERVICE_URL=$$($(GCLOUD) run services describe $(CLOUD_RUN_SERVICE) \
-		--region $(CLOUD_RUN_REGION) \
-		--format 'value(status.url)' 2>/dev/null) && \
-	if [ -n "$$SERVICE_URL" ]; then \
-		echo "✅ Service URL: $$SERVICE_URL"; \
-	fi
-	@echo "✅ Domain: https://giftwiki-dev.leetserve.com (update DNS if not already pointing to Cloud Run)"
+	@echo "✅ Infrastructure ready."
+	@echo "   To deploy the app locally, set DEV_* env vars and run: make deploy-app-dev"
+
+deploy-app-dev:
+	@echo "Deploying Cloud Run application (dev)..."
+	@SUBS="^;^"; \
+	SUBS+="_SERVICE_NAME=$$DEV_SERVICE_NAME;"; \
+	SUBS+="_REGION=$$DEV_REGION"; \
+	$(GCLOUD) builds submit --config=cloudbuild.yaml --substitutions="$$SUBS"
 
 # Verify Cloud Run secrets are set up correctly
 cloud-run-verify-secrets:
@@ -346,14 +345,28 @@ terraform-ensure-infra: terraform-init
 	@echo "✅ Infrastructure managed by Terraform"
 
 # Deploy to Cloud Run (Prod)
+# App deployment is handled by GitHub Actions (deploy.yml) using repository variables.
+# To deploy locally, set PROD_* env vars (PROD_SERVICE_NAME, PROD_REGION, PROD_DB_HOST,
+# PROD_DB_NAME, PROD_FIREBASE_API_KEY_SECRET, PROD_ALLOWED_USERS_SECRET,
+# PROD_ALLOWED_HOSTS, PROD_ALLOWED_ORIGINS) and run: make deploy-app-prod
 prod: ENV=prod
 prod:
 	@echo "Step 1: Ensure infrastructure (secrets, IAM, Firebase Auth) with Terraform..."
 	@$(MAKE) terraform-init ENV=prod
 	@cd terraform && terraform workspace select prod
 	@cd terraform && terraform apply -auto-approve -var-file="prod.tfvars"
-	@echo "Step 2: Deploy Cloud Run application (builds image)..."
-	@$(GCLOUD) builds submit \
-		--config=cloudbuild.yaml \
-		--substitutions='^;^_SERVICE_NAME=giftwiki-prod;_REGION=us-east1;_DB_HOST=ep-falling-morning-ae2u6rxv-pooler.c-2.us-east-2.aws.neon.tech;_DB_NAME=neondb;_FIREBASE_API_KEY_SECRET=prod-firebase-api-key;_ALLOWED_USERS_SECRET=prod-django-allowed-users;_ALLOWED_HOSTS=giftwiki.leetserve.com,giftwiki-prod-tshpxht2la-ue.a.run.app,.a.run.app;_ALLOWED_ORIGINS=https://giftwiki.leetserve.com,https://giftwiki-prod-tshpxht2la-ue.a.run.app'
-	@echo "✅ Domain: https://giftwiki.leetserve.com (update DNS if not already pointing to Cloud Run)"
+	@echo "✅ Infrastructure ready."
+	@echo "   To deploy the app locally, set PROD_* env vars and run: make deploy-app-prod"
+
+deploy-app-prod:
+	@echo "Deploying Cloud Run application (prod)..."
+	@SUBS="^;^"; \
+	SUBS+="_SERVICE_NAME=$$PROD_SERVICE_NAME;"; \
+	SUBS+="_REGION=$$PROD_REGION;"; \
+	SUBS+="_DB_HOST=$$PROD_DB_HOST;"; \
+	SUBS+="_DB_NAME=$$PROD_DB_NAME;"; \
+	SUBS+="_FIREBASE_API_KEY_SECRET=$$PROD_FIREBASE_API_KEY_SECRET;"; \
+	SUBS+="_ALLOWED_USERS_SECRET=$$PROD_ALLOWED_USERS_SECRET;"; \
+	SUBS+="_ALLOWED_HOSTS=$$PROD_ALLOWED_HOSTS;"; \
+	SUBS+="_ALLOWED_ORIGINS=$$PROD_ALLOWED_ORIGINS"; \
+	$(GCLOUD) builds submit --config=cloudbuild.yaml --substitutions="$$SUBS"

--- a/Makefile
+++ b/Makefile
@@ -258,10 +258,8 @@ dev:
 
 deploy-app-dev:
 	@echo "Deploying Cloud Run application (dev)..."
-	@SUBS="^;^"; \
-	SUBS+="_SERVICE_NAME=$$DEV_SERVICE_NAME;"; \
-	SUBS+="_REGION=$$DEV_REGION"; \
-	$(GCLOUD) builds submit --config=cloudbuild.yaml --substitutions="$$SUBS"
+	@$(GCLOUD) builds submit --config=cloudbuild.yaml \
+		--substitutions="_SERVICE_NAME=giftwiki-dev,_REGION=us-east1"
 
 # Verify Cloud Run secrets are set up correctly
 cloud-run-verify-secrets:

--- a/Makefile
+++ b/Makefile
@@ -355,5 +355,5 @@ prod:
 	@echo "Step 2: Deploy Cloud Run application (builds image)..."
 	@$(GCLOUD) builds submit \
 		--config=cloudbuild.yaml \
-		--substitutions=^;^_SERVICE_NAME=giftwiki-prod;_REGION=us-east1;_DB_HOST=ep-falling-morning-ae2u6rxv-pooler.c-2.us-east-2.aws.neon.tech;_DB_NAME=neondb;_FIREBASE_API_KEY_SECRET=prod-firebase-api-key;_ALLOWED_USERS_SECRET=prod-django-allowed-users;_ALLOWED_HOSTS=giftwiki.leetserve.com,giftwiki-prod-tshpxht2la-ue.a.run.app,.a.run.app;_ALLOWED_ORIGINS=https://giftwiki.leetserve.com,https://giftwiki-prod-tshpxht2la-ue.a.run.app
+		--substitutions='^;^_SERVICE_NAME=giftwiki-prod;_REGION=us-east1;_DB_HOST=ep-falling-morning-ae2u6rxv-pooler.c-2.us-east-2.aws.neon.tech;_DB_NAME=neondb;_FIREBASE_API_KEY_SECRET=prod-firebase-api-key;_ALLOWED_USERS_SECRET=prod-django-allowed-users;_ALLOWED_HOSTS=giftwiki.leetserve.com,giftwiki-prod-tshpxht2la-ue.a.run.app,.a.run.app;_ALLOWED_ORIGINS=https://giftwiki.leetserve.com,https://giftwiki-prod-tshpxht2la-ue.a.run.app'
 	@echo "✅ Domain: https://giftwiki.leetserve.com (update DNS if not already pointing to Cloud Run)"


### PR DESCRIPTION
## Summary
- Previous fix used `^;^` as the gcloud `--substitutions` separator to avoid `:` conflicting with `https://` URLs
- But `;` is a shell command separator, so the arg was split and `--substitutions` only received `^`
- Quoted the value with single quotes so the shell passes it verbatim to gcloud

## Test plan
- [ ] Verify Deploy Production workflow step 2 builds and deploys the Cloud Run image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)