### PR TITLE
feat: use GH Actions environments for dev/prod config isolation

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,12 +6,13 @@ on:
 jobs:
   deploy-dev:
     runs-on: ubuntu-latest
+    environment: development
     env:
       GOOGLE_PROJECT: wikileet
       GOOGLE_PROJECT_ID: wikileet
       GOOGLE_CLOUD_QUOTA_PROJECT: wikileet
       GCLOUD: gcloud
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -81,5 +82,7 @@ jobs:
 
       - name: Deploy Cloud Run (dev)
         run: |
-          gcloud builds submit --config=cloudbuild.yaml \
-            --substitutions="_SERVICE_NAME=giftwiki-dev,_REGION=us-east1"
+          SUBS="^;^"
+          SUBS+="_SERVICE_NAME=${{ vars.SERVICE_NAME }};"
+          SUBS+="_REGION=${{ vars.REGION }}"
+          gcloud builds submit --config=cloudbuild.yaml --substitutions="${SUBS}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,12 +9,13 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: production
     env:
       GOOGLE_PROJECT: wikileet
       GOOGLE_PROJECT_ID: wikileet
       GOOGLE_CLOUD_QUOTA_PROJECT: wikileet
       GCLOUD: gcloud
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -85,12 +86,12 @@ jobs:
       - name: Deploy Cloud Run (prod)
         run: |
           SUBS="^;^"
-          SUBS+="_SERVICE_NAME=${{ vars.PROD_SERVICE_NAME }};"
-          SUBS+="_REGION=${{ vars.PROD_REGION }};"
-          SUBS+="_DB_HOST=${{ vars.PROD_DB_HOST }};"
-          SUBS+="_DB_NAME=${{ vars.PROD_DB_NAME }};"
-          SUBS+="_FIREBASE_API_KEY_SECRET=${{ vars.PROD_FIREBASE_API_KEY_SECRET }};"
-          SUBS+="_ALLOWED_USERS_SECRET=${{ vars.PROD_ALLOWED_USERS_SECRET }};"
-          SUBS+="_ALLOWED_HOSTS=${{ vars.PROD_ALLOWED_HOSTS }};"
-          SUBS+="_ALLOWED_ORIGINS=${{ vars.PROD_ALLOWED_ORIGINS }}"
+          SUBS+="_SERVICE_NAME=${{ vars.SERVICE_NAME }};"
+          SUBS+="_REGION=${{ vars.REGION }};"
+          SUBS+="_DB_HOST=${{ vars.DB_HOST }};"
+          SUBS+="_DB_NAME=${{ vars.DB_NAME }};"
+          SUBS+="_FIREBASE_API_KEY_SECRET=${{ vars.FIREBASE_API_KEY_SECRET }};"
+          SUBS+="_ALLOWED_USERS_SECRET=${{ vars.ALLOWED_USERS_SECRET }};"
+          SUBS+="_ALLOWED_HOSTS=${{ vars.ALLOWED_HOSTS }};"
+          SUBS+="_ALLOWED_ORIGINS=${{ vars.ALLOWED_ORIGINS }}"
           gcloud builds submit --config=cloudbuild.yaml --substitutions="${SUBS}"


### PR DESCRIPTION
## Summary
- Add `environment: production` to `deploy.yml` and `environment: development` to `deploy-dev.yml`
- Each environment has its own scoped variables — no more `PROD_`/`DEV_` prefixes
- Both workflows now reference unprefixed `vars.SERVICE_NAME`, `vars.REGION`, etc., resolved per-environment at runtime
- Production environment has 8 variables covering service config, DB, Firebase, and allowed hosts/origins
- Development environment has 2 variables (SERVICE_NAME, REGION)

## Test plan
- [ ] Merge triggers `Deploy Production` workflow using `production` environment variables
- [ ] PR against main triggers `Deploy Review Environment (Dev)` using `development` environment variables
- [ ] Confirm prod Cloud Run deploy succeeds with correct service name and substitutions
- [ ] Confirm dev Cloud Run deploy succeeds with correct service name

## Notes
Repo-level secrets (`DJANGO_DB_PASSWORD`, `GCP_CREDENTIALS`, etc.) still work as fallback until moved into the environment-scoped secrets via the GitHub UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)