### PR TITLE
test: unblock pytest by defaulting DJANGO_ALLOWED_USERS in conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,10 @@
 Pytest configuration and shared fixtures for the gift wiki project.
 """
 
+import os
+
+os.environ.setdefault('DJANGO_ALLOWED_USERS', 'test@example.com,other@example.com')
+
 import pytest
 from django.contrib.auth import get_user_model
 


### PR DESCRIPTION
Closes #35

## Summary
- `FirebaseAuthMiddleware.__init__` raises `ImproperlyConfigured` when `DJANGO_ALLOWED_USERS` is unset; this caused every test to error at middleware init rather than report a real pass/fail.
- Set a default via `os.environ.setdefault(...)` at the top of the root `conftest.py`, before Django imports.
- `setdefault` preserves any intentionally-set value — a future test that wants to exercise the `ImproperlyConfigured` branch can `monkeypatch.delenv('DJANGO_ALLOWED_USERS')` locally.

## Why `conftest.py` instead of `pytest.ini [env]`
The issue originally proposed an `env =` block in `pytest.ini`. That requires the `pytest-env` plugin, which is **not** in `Pipfile` or `Pipfile.lock`. The `conftest.py` approach avoids adding a new dev dependency and still guarantees the env var is set before Django initializes.

## Baseline after this change
`make test` → **26 passed, 1 failed** in ~5s. The single failure is `tests/api/test_business_rules.py::TestPurchaseVisibility::test_everyone_can_see_purchase_status`, which is a legitimate test bug — in scope for part 2 (#36), not this part.

## Test plan
- [x] `make test` completes without any `ImproperlyConfigured` errors
- [x] `make lint` passes
- [ ] Reviewer confirms baseline pass/fail matches expectations and approves rollout of part 2 (#36) next

🤖 Generated with [Claude Code](https://claude.com/claude-code)