### PR TITLE
test: pytest coverage for middleware, sessionLogin, public pages

### DIFF
--- a/tests/api/test_middleware.py
+++ b/tests/api/test_middleware.py
@@ -1,0 +1,46 @@
+"""Tests for middleware that runs early in the request chain (no auth required)."""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+@pytest.mark.unit
+class TestHealthCheckMiddleware:
+    def test_health_endpoint_returns_200_unauthenticated(self, client, db):
+        response = client.get('/health/')
+        assert response.status_code == 200
+        assert response.content == b'ok'
+
+
+@pytest.mark.unit
+class TestMetricsMiddleware:
+    def test_metrics_endpoint_returns_200_unauthenticated(self, client):
+        response = client.get('/metrics')
+        assert response.status_code == 200
+        assert 'text/plain' in response['Content-Type']
+
+    def test_metrics_endpoint_with_trailing_slash_returns_200(self, client):
+        response = client.get('/metrics/')
+        assert response.status_code == 200
+        assert 'text/plain' in response['Content-Type']
+
+
+@pytest.mark.unit
+class TestFirebaseAuthAllowlist:
+    def test_disallowed_email_returns_403(self, client, db):
+        """A successfully-authenticated user whose email is not in the allowlist gets 403."""
+        denied_user = User.objects.create_user(username='denied', email='denied@example.com')
+
+        with patch(
+            'gift.middleware.firebase_auth.FirebaseAuthBackend.authenticate',
+            return_value=denied_user,
+        ):
+            client.cookies['__session'] = 'fake-session-cookie'
+            response = client.get('/')
+
+        assert response.status_code == 403
+        assert b'not authorized' in response.content

--- a/tests/api/test_public_pages.py
+++ b/tests/api/test_public_pages.py
@@ -1,0 +1,16 @@
+"""Tests for public pages that render without authentication."""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestPublicPages:
+    def test_privacy_page_renders_unauthenticated(self, client):
+        response = client.get('/privacy/')
+        assert response.status_code == 200
+        assert 'gift/privacy.html' in [t.name for t in response.templates]
+
+    def test_data_deletion_page_renders_unauthenticated(self, client):
+        response = client.get('/data-deletion/')
+        assert response.status_code == 200
+        assert 'gift/data_deletion.html' in [t.name for t in response.templates]

--- a/tests/api/test_session_login.py
+++ b/tests/api/test_session_login.py
@@ -1,0 +1,32 @@
+"""Tests for /sessionLogin request validation.
+
+The Firebase Admin SDK verify path is intentionally not exercised here per issue #37 —
+these tests cover only the input-validation branches that fail before reaching the SDK.
+"""
+
+import json
+
+import pytest
+
+
+@pytest.mark.unit
+class TestSessionLoginValidation:
+    def test_empty_body_returns_400(self, client):
+        response = client.post('/sessionLogin', data=b'', content_type='application/json')
+        assert response.status_code == 400
+        assert json.loads(response.content) == {'error': 'Invalid JSON body'}
+
+    def test_invalid_json_returns_400(self, client):
+        response = client.post('/sessionLogin', data=b'{not json', content_type='application/json')
+        assert response.status_code == 400
+        assert json.loads(response.content) == {'error': 'Invalid JSON body'}
+
+    def test_missing_id_token_returns_400(self, client):
+        response = client.post('/sessionLogin', data='{}', content_type='application/json')
+        assert response.status_code == 400
+        body = json.loads(response.content)
+        assert 'ID token' in body['error']
+
+    def test_get_method_not_allowed(self, client):
+        response = client.get('/sessionLogin')
+        assert response.status_code == 405


### PR DESCRIPTION
Closes #37 — Test suite part 3 of 6.

## Summary
- `tests/api/test_middleware.py` — `/health/` (200, body `ok`), `/metrics` and `/metrics/` (200, prometheus content-type), and a 403 path for an authenticated user whose email is outside the allowlist (patches `FirebaseAuthBackend.authenticate`).
- `tests/api/test_session_login.py` — four validation branches of `/sessionLogin`: empty body, invalid JSON, missing `idToken`, and GET → 405. Firebase verify path is intentionally not exercised per the issue — these requests fail validation before reaching the SDK.
- `tests/api/test_public_pages.py` — `/privacy/` and `/data-deletion/` render unauthenticated and use the expected templates.

All tests use `@pytest.mark.unit` to match the existing `tests/api/` style. No conftest changes; existing fixtures cover everything needed.

## Test plan
- [x] `make test` — 36 passed, 1 xfailed (pre-existing)
- [x] `make lint` — clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)