### PR TITLE
test: allowlist + feature-flags BDD + CI workflow (part 6 of 6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: Test Suite
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pipenv
+        run: python -m pip install --upgrade pip pipenv
+
+      - name: Cache pipenv virtualenv
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/virtualenvs
+          key: ${{ runner.os }}-pipenv-${{ hashFiles('Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pipenv-
+
+      - name: Install dependencies
+        run: pipenv install --dev --skip-lock --python 3.12
+
+      - name: Run lint
+        run: make lint
+
+      - name: Run tests
+        run: make test

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,9 +13,15 @@ tests/
 │   ├── test_business_rules.py
 │   └── test_views.py
 ├── features/         # Gherkin .feature files (BDD specs)
-│   └── ownership.feature
+│   ├── allowlist.feature
+│   ├── feature_flags.feature
+│   ├── ownership.feature
+│   └── purchase.feature
 └── steps/            # Step definitions (pytest-bdd)
-    └── test_ownership.py
+    ├── test_allowlist.py
+    ├── test_feature_flags.py
+    ├── test_ownership.py
+    └── test_purchase.py
 ```
 
 Shared fixtures live in the project-root `conftest.py` (not `tests/conftest.py`).
@@ -128,6 +134,12 @@ def item_name_is(owned_item, expected_name):
 
 Run `make test-bdd` (or `pipenv run pytest -m bdd`) to exercise just the BDD
 scenarios.
+
+## CI
+
+The `.github/workflows/test.yml` workflow runs `make lint` and `make test` on
+every pull request and on pushes to `main`. No repo secrets are required —
+`conftest.py` defaults `DJANGO_ALLOWED_USERS` so the suite is self-bootstrapping.
 
 ## Debugging
 

--- a/tests/features/allowlist.feature
+++ b/tests/features/allowlist.feature
@@ -1,0 +1,20 @@
+Feature: Email allowlist enforcement
+  The Firebase authentication middleware enforces a comma-separated
+  allowlist from DJANGO_ALLOWED_USERS. A user whose email is in the
+  allowlist is authenticated; a user whose email is not gets a 403.
+  If the env var is empty or unset, the middleware refuses to start.
+
+  Scenario: Allowed email is authenticated
+    Given a Firebase session for email "test@example.com"
+    When the user requests the home page
+    Then the response status is 200
+
+  Scenario: Disallowed email gets a 403
+    Given a Firebase session for email "intruder@example.com"
+    When the user requests the home page
+    Then the response status is 403
+
+  Scenario: Empty DJANGO_ALLOWED_USERS refuses to start
+    Given DJANGO_ALLOWED_USERS is unset
+    When the Firebase auth middleware is constructed
+    Then it raises ImproperlyConfigured

--- a/tests/features/feature_flags.feature
+++ b/tests/features/feature_flags.feature
@@ -1,0 +1,27 @@
+Feature: Runtime feature flags
+  Two feature flags gate optional behavior: STEWARD_PROXY_ENABLED controls
+  whether a wishlist's dependent ("steward") may edit the list, and
+  PROFILE_PICTURE_ENABLED controls whether the profile page renders the
+  picture upload field.
+
+  Scenario: Steward proxy on — dependent can open the edit page
+    Given the other user is the dependent on the wishlist
+    And STEWARD_PROXY_ENABLED is on
+    When the dependent opens the wishlist edit page
+    Then the response status is 200
+
+  Scenario: Steward proxy off — dependent cannot open the edit page
+    Given the other user is the dependent on the wishlist
+    And STEWARD_PROXY_ENABLED is off
+    When the dependent opens the wishlist edit page
+    Then the response status is 302
+
+  Scenario: Profile picture flag on — profile page renders the upload field
+    Given PROFILE_PICTURE_ENABLED is on
+    When the user opens the profile page
+    Then the page shows the profile picture field
+
+  Scenario: Profile picture flag off — profile page hides the upload field
+    Given PROFILE_PICTURE_ENABLED is off
+    When the user opens the profile page
+    Then the page does not show the profile picture field

--- a/tests/steps/test_allowlist.py
+++ b/tests/steps/test_allowlist.py
@@ -1,0 +1,71 @@
+"""BDD step definitions for allowlist.feature.
+
+The Firebase middleware decides allow/deny based on the email returned by
+``FirebaseAuthBackend.authenticate``. These tests mock that method so we
+don't need a real Firebase session cookie. The conftest-level
+``DJANGO_ALLOWED_USERS`` = ``test@example.com,other@example.com`` is the
+allowlist used by the already-initialized middleware instance.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.test import Client
+from pytest_bdd import given, parsers, scenarios, then, when
+
+pytestmark = pytest.mark.bdd
+
+scenarios(str(Path(__file__).parent.parent / 'features' / 'allowlist.feature'))
+
+
+@given(parsers.parse('a Firebase session for email "{email}"'), target_fixture='session_email')
+def session_email(email):
+    return email
+
+
+@when('the user requests the home page', target_fixture='response')
+def request_home(db, monkeypatch, session_email):
+    mock_user = MagicMock()
+    mock_user.email = session_email
+    mock_user.username = session_email.split('@')[0]
+    mock_user.is_authenticated = True
+
+    from gift.middleware import firebase_auth
+
+    monkeypatch.setattr(
+        firebase_auth.FirebaseAuthBackend,
+        'authenticate',
+        lambda self, request: mock_user,
+    )
+
+    client = Client()
+    client.cookies['__session'] = 'dummy-session-cookie'
+    return client.get('/')
+
+
+@then(parsers.parse('the response status is {status:d}'))
+def assert_status(response, status):
+    assert response.status_code == status
+
+
+@given('DJANGO_ALLOWED_USERS is unset')
+def unset_allowlist(monkeypatch):
+    monkeypatch.setenv('DJANGO_ALLOWED_USERS', '')
+
+
+@when('the Firebase auth middleware is constructed', target_fixture='construction_error')
+def construct_middleware():
+    from gift.middleware.firebase_auth import FirebaseAuthMiddleware
+
+    try:
+        FirebaseAuthMiddleware(lambda request: None)
+    except ImproperlyConfigured as exc:
+        return exc
+    return None
+
+
+@then('it raises ImproperlyConfigured')
+def assert_improperly_configured(construction_error):
+    assert isinstance(construction_error, ImproperlyConfigured)

--- a/tests/steps/test_feature_flags.py
+++ b/tests/steps/test_feature_flags.py
@@ -1,0 +1,81 @@
+"""BDD step definitions for feature_flags.feature.
+
+Views import ``get_steward_proxy_enabled`` / ``get_profile_picture_enabled``
+inside the function body (`gift/views.py`), so patching the accessor on
+``giftwiki.feature_flags`` takes effect on the next request.
+"""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+pytestmark = pytest.mark.bdd
+
+scenarios(str(Path(__file__).parent.parent / 'features' / 'feature_flags.feature'))
+
+
+@given('the other user is the dependent on the wishlist')
+def assign_dependent(wishlist, other_user):
+    wishlist.dependent = other_user
+    wishlist.save()
+
+
+@given('STEWARD_PROXY_ENABLED is on')
+def steward_on(monkeypatch):
+    monkeypatch.setattr(
+        'giftwiki.feature_flags.get_steward_proxy_enabled', lambda: True
+    )
+
+
+@given('STEWARD_PROXY_ENABLED is off')
+def steward_off(monkeypatch):
+    monkeypatch.setattr(
+        'giftwiki.feature_flags.get_steward_proxy_enabled', lambda: False
+    )
+
+
+@given('PROFILE_PICTURE_ENABLED is on')
+def profile_picture_on(monkeypatch):
+    monkeypatch.setattr(
+        'giftwiki.feature_flags.get_profile_picture_enabled', lambda: True
+    )
+
+
+@given('PROFILE_PICTURE_ENABLED is off')
+def profile_picture_off(monkeypatch):
+    monkeypatch.setattr(
+        'giftwiki.feature_flags.get_profile_picture_enabled', lambda: False
+    )
+
+
+@when('the dependent opens the wishlist edit page', target_fixture='response')
+def dependent_opens_edit(authenticated_other_user, wishlist):
+    return authenticated_other_user.get(f'/wishlist/{wishlist.id}/edit/')
+
+
+@when('the user opens the profile page', target_fixture='response')
+def user_opens_profile(authenticated_user):
+    return authenticated_user.get('/profile/')
+
+
+@then('the response status is 200')
+def assert_200(response):
+    assert response.status_code == 200
+
+
+@then('the response status is 302')
+def assert_302(response):
+    assert response.status_code == 302
+
+
+@then('the page shows the profile picture field')
+def page_shows_picture_field(response):
+    assert response.status_code == 200
+    assert 'name="profile_picture"' in response.content.decode()
+
+
+@then('the page does not show the profile picture field')
+def page_hides_picture_field(response):
+    assert response.status_code == 200
+    assert 'name="profile_picture"' not in response.content.decode()


### PR DESCRIPTION
Closes #40

## Summary
- `tests/features/allowlist.feature` (3 scenarios) — allowed email → 200, disallowed email → 403, empty `DJANGO_ALLOWED_USERS` → `ImproperlyConfigured`. Step defs mock `FirebaseAuthBackend.authenticate` so no real Firebase session cookie is required.
- `tests/features/feature_flags.feature` (4 scenarios) — steward proxy on/off gates `/wishlist/<id>/edit/` for the dependent; profile-picture flag on/off gates the upload field in the `/profile/` template. Step defs monkey-patch the `get_*_enabled()` accessors on `giftwiki.feature_flags`.
- `.github/workflows/test.yml` — new Test Suite workflow: Python 3.12, pipenv, caches the virtualenv on `Pipfile.lock`, runs `make lint` and `make test` on every PR and on pushes to `main`. No secrets required (conftest seeds `DJANGO_ALLOWED_USERS`).
- Docs: layout + CI section in `tests/README.md`.

## Test plan
- [x] `make test-bdd` — 17 scenarios green (4 ownership + 6 purchase + 3 allowlist + 4 feature_flags)
- [x] `make test` — 53 passed, 1 xfailed (pre-existing, expected), 0 regressions
- [x] `make lint` — clean
- [ ] New GitHub Actions workflow runs green on this PR (will be visible after checks complete)

## Follow-up (out of scope)
- `Pipfile` pins `python_version = "3.10"` but we run tests on 3.12. CI uses `pipenv install --dev --skip-lock --python 3.12` to work around this; consider bumping the Pipfile declared version in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)