### PR TITLE
feat: hide purchase status from list owner and improve link UI

### DIFF
--- a/gift/templates/gift/wishlist_detail.html
+++ b/gift/templates/gift/wishlist_detail.html
@@ -25,7 +25,7 @@
            Add to view: context['total_count'] and context['purchased_count']
            by iterating sorted_category_items + uncategorized_items.
         {% endcomment %}
-        {% if total_count %}
+        {% if total_count and not is_list_manager %}
         <div class="wl-progress">
           <span class="wl-progress-label">
             <span class="wl-progress-mono">{{ purchased_count }}/{{ total_count }}</span> purchased
@@ -70,20 +70,19 @@
       </div>
 
       {% for item in category_items %}
-      <div class="wl-item-row{% if item.purchased %} purchased{% endif %}">
+      <div class="wl-item-row{% if item.purchased and not is_list_manager %} purchased{% endif %}">
         <div class="wl-item-main">
           <div class="wl-item-name">
+            <span>{{ item.name }}</span>
             {% if item.url %}
-              <a href="{{ item.url }}" target="_blank" rel="noopener" class="wl-item-name-link">{{ item.name }}
+              <a href="{{ item.url }}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary" style="padding: 2px 6px; font-size: 11px; margin-left: 6px; display: inline-flex; align-items: center; gap: 4px; vertical-align: middle;">
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                     style="color:var(--text-muted);display:inline;">
+                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
                   <polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>
                 </svg>
+                Link
               </a>
-            {% else %}
-              <span>{{ item.name }}</span>
             {% endif %}
             {% if item.price_range %}
               <span class="badge-price">{{ item.get_price_range_display }}</span>
@@ -145,20 +144,19 @@
       </div>
 
       {% for item in uncategorized_items %}
-      <div class="wl-item-row{% if item.purchased %} purchased{% endif %}">
+      <div class="wl-item-row{% if item.purchased and not is_list_manager %} purchased{% endif %}">
         <div class="wl-item-main">
           <div class="wl-item-name">
+            <span>{{ item.name }}</span>
             {% if item.url %}
-              <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.name }}
+              <a href="{{ item.url }}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary" style="padding: 2px 6px; font-size: 11px; margin-left: 6px; display: inline-flex; align-items: center; gap: 4px; vertical-align: middle;">
                 <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                     style="color:var(--text-muted);display:inline;">
+                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                   <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
                   <polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>
                 </svg>
+                Link
               </a>
-            {% else %}
-              <span>{{ item.name }}</span>
             {% endif %}
             {% if item.price_range %}
               <span class="badge-price">{{ item.get_price_range_display }}</span>


### PR DESCRIPTION
Ensures that the list owner (manager) cannot see whether an item was purchased to avoid ruining surprises. Also improves the link visibility by rendering a standalone 'Link' button next to the item name.