### PR TITLE
feat: add admin action to merge wishlists

### DIFF
--- a/gift/admin.py
+++ b/gift/admin.py
@@ -19,7 +19,48 @@ User = get_user_model()
 
 admin.site.register(User)
 admin.site.register(Family)
-admin.site.register(WishList)
+from django.shortcuts import render
+from django.http import HttpResponseRedirect
+from django.contrib import messages
+import django.contrib.admin.helpers as admin_helpers
+
+@admin.register(WishList)
+class WishListAdmin(admin.ModelAdmin):
+    list_display = ['title', 'owner']
+    search_fields = ['title', 'owner__username']
+    actions = ['merge_wishlists']
+
+    def merge_wishlists(self, request, queryset):
+        if 'apply' in request.POST:
+            primary_id = request.POST.get('primary_wishlist')
+            if not primary_id:
+                self.message_user(request, "No primary wishlist selected.", level=messages.ERROR)
+                return HttpResponseRedirect(request.get_full_path())
+            
+            primary_wl = queryset.get(id=primary_id)
+            secondary_wls = queryset.exclude(id=primary_id)
+            
+            for secondary in secondary_wls:
+                secondary.items.all().update(wishlist=primary_wl)
+                secondary.groups.all().update(wishlist=primary_wl)
+                
+                for manager in secondary.managers.all():
+                    primary_wl.managers.add(manager)
+                    
+                secondary.delete()
+                
+            self.message_user(request, f"Successfully merged wishlists into '{primary_wl}'.")
+            return HttpResponseRedirect(request.get_full_path())
+            
+        context = {
+            'title': 'Merge Wishlists',
+            'wishlists': queryset,
+            'queryset': queryset,
+            'opts': self.model._meta,
+            'action_checkbox_name': admin_helpers.ACTION_CHECKBOX_NAME,
+        }
+        return render(request, 'admin/gift/wishlist/merge_wishlists.html', context)
+    merge_wishlists.short_description = "Merge selected wishlists"
 admin.site.register(Item)
 admin.site.register(Suggestion)
 admin.site.register(ItemGroup)

--- a/gift/templates/admin/gift/wishlist/merge_wishlists.html
+++ b/gift/templates/admin/gift/wishlist/merge_wishlists.html
@@ -1,0 +1,39 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<form action="" method="post">
+    {% csrf_token %}
+    
+    <p>You have selected the following wishlists to merge:</p>
+    <ul>
+        {% for wishlist in wishlists %}
+        <li>{{ wishlist }} (Owner: {{ wishlist.owner.username }})</li>
+        {% endfor %}
+    </ul>
+    
+    <p>Please select the <strong>Primary Wishlist</strong>. All items and groups from the other selected wishlists will be moved into this one, and the other wishlists will be deleted.</p>
+    
+    <div>
+        <label for="primary_wishlist">Primary Wishlist:</label>
+        <select name="primary_wishlist" id="primary_wishlist" required>
+            <option value="">-- Select Primary --</option>
+            {% for wishlist in wishlists %}
+            <option value="{{ wishlist.id }}">{{ wishlist }} (Owner: {{ wishlist.owner.username }})</option>
+            {% endfor %}
+        </select>
+    </div>
+    
+    <br>
+    
+    {% for obj in queryset %}
+    <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk }}">
+    {% endfor %}
+    <input type="hidden" name="action" value="merge_wishlists">
+    <input type="hidden" name="apply" value="1">
+    
+    <div>
+        <input type="submit" value="Merge Wishlists">
+        <a href="#" onclick="window.history.back(); return false;" class="button cancel-link">Cancel</a>
+    </div>
+</form>
+{% endblock %}


### PR DESCRIPTION
This PR adds a custom admin action to allow administrators to merge two or more wishlists together. It includes an intermediate selection page to choose the primary wishlist that will retain the items, suggestions, and groups.