### PR TITLE
feat: display birthdays and add category creation modal

### DIFF
--- a/gift/forms.py
+++ b/gift/forms.py
@@ -20,13 +20,7 @@ class ItemForm(forms.ModelForm):
         queryset=None,
         required=False,
         label='Category',
-        help_text='Select an existing category or create a new one below',
-    )
-    new_category_name = forms.CharField(
-        max_length=255,
-        required=False,
-        label='Or Create New Category',
-        help_text='Enter a name to create a new category (optional)',
+        help_text='Select an existing category',
     )
 
     class Meta:
@@ -76,10 +70,6 @@ class ItemForm(forms.ModelForm):
                         )
             self.fields['category'].queryset = base_queryset
             self.fields['category'].empty_label = 'Select Existing Category (Optional)'
-            # Add "Create new..." option to the widget choices
-            original_choices = list(self.fields['category'].widget.choices)
-            original_choices.append(('__CREATE_NEW__', '+ Create New Category'))
-            self.fields['category'].widget.choices = original_choices
         else:
             # If no family, only show categories that also have no family
             # or include current item's category if editing
@@ -96,10 +86,6 @@ class ItemForm(forms.ModelForm):
             else:
                 self.fields['category'].queryset = Category.objects.filter(family__isnull=True)
             self.fields['category'].empty_label = 'No family selected - select a family first'
-            # Add "Create new..." option to the widget choices
-            original_choices = list(self.fields['category'].widget.choices)
-            original_choices.append(('__CREATE_NEW__', '+ Create New Category'))
-            self.fields['category'].widget.choices = original_choices
 
         # Set initial category if editing an existing item
         if self.instance and self.instance.pk:
@@ -109,29 +95,6 @@ class ItemForm(forms.ModelForm):
                 # Set initial value if the category is in the queryset
                 if category.id in self.fields['category'].queryset.values_list('id', flat=True):
                     self.fields['category'].initial = category.id
-
-    def full_clean(self):
-        """Override to handle '__CREATE_NEW__' before ModelChoiceField validation fails."""
-        super().full_clean()
-
-        # Check if category field has a validation error and if the raw value is '__CREATE_NEW__'
-        if 'category' in self.errors:
-            field_name = self.add_prefix('category')
-            raw_value = self.data.get(field_name) if hasattr(self, 'data') and self.data else None
-
-            if raw_value == '__CREATE_NEW__':
-                # Remove the validation error and set the cleaned value
-                del self.errors['category']
-                self.cleaned_data['category'] = '__CREATE_NEW__'
-
-    def clean_category(self):
-        """Allow '__CREATE_NEW__' as a valid choice."""
-        category = self.cleaned_data.get('category')
-        # If it's already '__CREATE_NEW__' (set in full_clean), return it
-        if category == '__CREATE_NEW__':
-            return '__CREATE_NEW__'
-        # Otherwise return the normal category value
-        return category
 
     def clean_description(self):
         description = self.cleaned_data.get('description', '')
@@ -162,51 +125,11 @@ class ItemForm(forms.ModelForm):
             instance.save()
             # Handle category assignment (ManyToMany needs saved instance)
             category = self.cleaned_data.get('category')
-            new_category_name = self.cleaned_data.get('new_category_name')
 
             # Clear existing categories
             instance.categories.clear()
 
-            # Handle "Create new..." option
-            if category == '__CREATE_NEW__':
-                if new_category_name and wishlist and wishlist.family_name:
-                    from .models import Category
-
-                    category_obj, created = Category.objects.get_or_create(
-                        name=new_category_name,
-                        family=wishlist.family_name,
-                        defaults={'description': f'Category for {new_category_name}'},
-                    )
-                    if created:
-                        logger.info(
-                            'Category created',
-                            extra={
-                                'category_id': category_obj.id,
-                                'name': new_category_name,
-                                'family_id': wishlist.family_name_id,
-                            },
-                        )
-                    instance.categories.add(category_obj)
-            elif new_category_name and wishlist and wishlist.family_name:
-                # If new category name provided, create it (takes precedence)
-                from .models import Category
-
-                category_obj, created = Category.objects.get_or_create(
-                    name=new_category_name,
-                    family=wishlist.family_name,
-                    defaults={'description': f'Category for {new_category_name}'},
-                )
-                if created:
-                    logger.info(
-                        'Category created',
-                        extra={
-                            'category_id': category_obj.id,
-                            'name': new_category_name,
-                            'family_id': wishlist.family_name_id,
-                        },
-                    )
-                instance.categories.add(category_obj)
-            elif category and category != '__CREATE_NEW__':
+            if category:
                 instance.categories.add(category)
         return instance
 
@@ -224,8 +147,7 @@ def get_item_modelformset(wishlist):
         pass
 
     # Include all editable fields from Item model
-    # Note: category and new_category_name are not model fields, they're form fields
-    # so we need to handle them in the form itself
+    # Note: category is not a model field, it's a form field handled in ItemForm
     ItemModelFormSet = modelformset_factory(
         Item,
         form=ItemEditForm,

--- a/gift/static/css/custom.css
+++ b/gift/static/css/custom.css
@@ -320,6 +320,7 @@ label { font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bo
 .wl-list-row-right { display: flex; align-items: center; gap: 10px; }
 .wl-list-title { font-weight: 500; font-size: 14px; }
 .wl-list-owner { font-size: 12px; color: var(--text-muted); margin-top: 1px; }
+.wl-list-birthday { font-size: 11px; color: var(--text-secondary); margin-top: 2px; }
 .wl-list-meta  { font-family: var(--font-mono); font-size: 10px; font-weight: 500; color: var(--text-muted); }
 
 /* Category header */

--- a/gift/templates/gift/home.html
+++ b/gift/templates/gift/home.html
@@ -1,5 +1,6 @@
 {% extends 'gift/base/base_generic.html' %}
 {% load static %}
+{% load gift_extras %}
 
 {% block extra_head %}
 <style>
@@ -77,6 +78,11 @@
                   {{ wishlist.owner.get_full_name|default:wishlist.owner.username }}
                 {% endif %}
               </div>
+              {% with person=wishlist.dependent|default:wishlist.owner %}
+                {% if person.birthday %}
+                  <div class="wl-list-birthday">{{ person|birthday_label }}</div>
+                {% endif %}
+              {% endwith %}
             </div>
           </div>
 

--- a/gift/templates/gift/item_add.html
+++ b/gift/templates/gift/item_add.html
@@ -77,7 +77,12 @@
           <div class="col-sm-6">
             <div class="form-group">
               <label for="{{ form.category.id_for_label }}">{{ form.category.label }}</label>
-              {{ form.category|add_class:"form-control" }}
+              <div style="display:flex;gap:8px;">
+                {{ form.category|add_class:"form-control" }}
+                <button type="button" class="btn btn-outline-secondary" id="newCategoryBtn" style="white-space:nowrap;">
+                  + New Category
+                </button>
+              </div>
               {% if form.category.help_text %}
                 <small class="form-text">{{ form.category.help_text }}</small>
               {% endif %}
@@ -88,20 +93,6 @@
           </div>
           {% endif %}
         </div>
-
-        {# New category name (shown conditionally by JS below) #}
-        {% if wishlist.family_name %}
-        <div class="form-group" id="newCategoryGroup" style="display:none;">
-          <label for="{{ form.new_category_name.id_for_label }}">{{ form.new_category_name.label }}</label>
-          {{ form.new_category_name|add_class:"form-control"|attr:"placeholder:e.g. Tech, Books, Clothing…" }}
-          {% if form.new_category_name.help_text %}
-            <small class="form-text">{{ form.new_category_name.help_text }}</small>
-          {% endif %}
-          {% for error in form.new_category_name.errors %}
-            <div class="text-danger">{{ error }}</div>
-          {% endfor %}
-        </div>
-        {% endif %}
 
         {# Product URL (add `url` to ItemForm if not already included) #}
         {% if form.url %}
@@ -126,24 +117,33 @@
 
 </div>
 
+<!-- New Category Modal -->
+<div class="modal fade" id="newCategoryModal" tabindex="-1" role="dialog" aria-labelledby="newCategoryModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="newCategoryModalLabel">Create New Category</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label for="newCategoryName">Category Name</label>
+          <input type="text" class="form-control" id="newCategoryName" placeholder="e.g. Tech, Books, Clothing…">
+          <div class="text-danger" id="newCategoryError" style="display:none;margin-top:4px;"></div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="saveNewCategoryBtn">Create Category</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script>
 (function () {
-  // Show "new category" field only when user selects the create-new option
-  var categorySelect = document.getElementById('{{ form.category.id_for_label }}');
-  var newGroup = document.getElementById('newCategoryGroup');
-
-  if (categorySelect && newGroup) {
-    function checkCategory() {
-      var val = categorySelect.value;
-      // Show if the selected option text starts with "Create" or value is empty/new
-      var selectedText = categorySelect.options[categorySelect.selectedIndex]
-                           ? categorySelect.options[categorySelect.selectedIndex].text : '';
-      newGroup.style.display = (selectedText.toLowerCase().indexOf('create') !== -1 || val === '') ? '' : 'none';
-    }
-    categorySelect.addEventListener('change', checkCategory);
-    checkCategory();
-  }
-
   // Initialize Quill editor
   var quill = new Quill('#quill-editor', {
     theme: 'snow',
@@ -170,6 +170,74 @@
       descInput.value = html;
       btn.disabled = true;
       btn.textContent = 'Adding…';
+    });
+  }
+
+  // New category modal handling
+  var categorySelect = document.getElementById('{{ form.category.id_for_label }}');
+  var newCategoryBtn = document.getElementById('newCategoryBtn');
+  var newCategoryModal = document.getElementById('newCategoryModal');
+  var newCategoryNameInput = document.getElementById('newCategoryName');
+  var saveNewCategoryBtn = document.getElementById('saveNewCategoryBtn');
+  var newCategoryError = document.getElementById('newCategoryError');
+
+  if (newCategoryBtn && newCategoryModal) {
+    newCategoryBtn.addEventListener('click', function () {
+      newCategoryNameInput.value = '';
+      newCategoryError.style.display = 'none';
+      newCategoryError.textContent = '';
+      $('#newCategoryModal').modal('show');
+      setTimeout(function () { newCategoryNameInput.focus(); }, 200);
+    });
+  }
+
+  if (saveNewCategoryBtn) {
+    saveNewCategoryBtn.addEventListener('click', function () {
+      var name = newCategoryNameInput.value.trim();
+      if (!name) {
+        newCategoryError.textContent = 'Please enter a category name.';
+        newCategoryError.style.display = 'block';
+        return;
+      }
+
+      saveNewCategoryBtn.disabled = true;
+      saveNewCategoryBtn.textContent = 'Creating…';
+
+      fetch('{% url "gift:create_category_ajax" wishlist.id %}', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+        },
+        body: JSON.stringify({name: name})
+      })
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        saveNewCategoryBtn.disabled = false;
+        saveNewCategoryBtn.textContent = 'Create Category';
+
+        if (data.status === 'success') {
+          // Add the new category to the dropdown and select it
+          var existingOption = categorySelect.querySelector('option[value="' + data.category_id + '"]');
+          if (!existingOption) {
+            var option = document.createElement('option');
+            option.value = data.category_id;
+            option.textContent = data.category_name;
+            categorySelect.appendChild(option);
+          }
+          categorySelect.value = data.category_id;
+          $('#newCategoryModal').modal('hide');
+        } else {
+          newCategoryError.textContent = data.message || 'Error creating category.';
+          newCategoryError.style.display = 'block';
+        }
+      })
+      .catch(function () {
+        saveNewCategoryBtn.disabled = false;
+        saveNewCategoryBtn.textContent = 'Create Category';
+        newCategoryError.textContent = 'An unexpected error occurred. Please try again.';
+        newCategoryError.style.display = 'block';
+      });
     });
   }
 })();

--- a/gift/templates/gift/item_edit.html
+++ b/gift/templates/gift/item_edit.html
@@ -76,23 +76,18 @@
                     {# Category Selection - Always show, but warn if no family #}
                     <div class="form-group">
                         <label for="{{ form.category.id_for_label }}">{{ form.category.label }}</label>
-                        {{ form.category|add_class:"form-control" }}
+                        <div style="display:flex;gap:8px;">
+                            {{ form.category|add_class:"form-control" }}
+                            {% if wishlist.family_name %}
+                            <button type="button" class="btn btn-outline-secondary" id="newCategoryBtn" style="white-space:nowrap;">
+                                + New Category
+                            </button>
+                            {% endif %}
+                        </div>
                         {% if form.category.help_text %}
                             <small class="form-text text-muted">{{ form.category.help_text }}</small>
                         {% endif %}
                         {% for error in form.category.errors %}
-                            <div class="text-danger">{{ error }}</div>
-                        {% endfor %}
-                    </div>
-                    
-                    {# New Category Creation #}
-                    <div class="form-group">
-                        <label for="{{ form.new_category_name.id_for_label }}">{{ form.new_category_name.label }}</label>
-                        {{ form.new_category_name|add_class:"form-control" }}
-                        {% if form.new_category_name.help_text %}
-                            <small class="form-text text-muted">{{ form.new_category_name.help_text }}</small>
-                        {% endif %}
-                        {% for error in form.new_category_name.errors %}
                             <div class="text-danger">{{ error }}</div>
                         {% endfor %}
                     </div>
@@ -102,6 +97,31 @@
             </div>
         </div>
     </div>
+
+<!-- New Category Modal -->
+<div class="modal fade" id="newCategoryModal" tabindex="-1" role="dialog" aria-labelledby="newCategoryModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="newCategoryModalLabel">Create New Category</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label for="newCategoryName">Category Name</label>
+          <input type="text" class="form-control" id="newCategoryName" placeholder="e.g. Tech, Books, Clothing…">
+          <div class="text-danger" id="newCategoryError" style="display:none;margin-top:4px;"></div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="saveNewCategoryBtn">Create Category</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 <script>
 (function () {
@@ -131,6 +151,72 @@
       descInput.value = html;
       btn.disabled = true;
       btn.textContent = 'Saving…';
+    });
+  }
+
+  // New category modal handling
+  var categorySelect = document.getElementById('{{ form.category.id_for_label }}');
+  var newCategoryBtn = document.getElementById('newCategoryBtn');
+  var newCategoryNameInput = document.getElementById('newCategoryName');
+  var saveNewCategoryBtn = document.getElementById('saveNewCategoryBtn');
+  var newCategoryError = document.getElementById('newCategoryError');
+
+  if (newCategoryBtn) {
+    newCategoryBtn.addEventListener('click', function () {
+      newCategoryNameInput.value = '';
+      newCategoryError.style.display = 'none';
+      newCategoryError.textContent = '';
+      $('#newCategoryModal').modal('show');
+      setTimeout(function () { newCategoryNameInput.focus(); }, 200);
+    });
+  }
+
+  if (saveNewCategoryBtn) {
+    saveNewCategoryBtn.addEventListener('click', function () {
+      var name = newCategoryNameInput.value.trim();
+      if (!name) {
+        newCategoryError.textContent = 'Please enter a category name.';
+        newCategoryError.style.display = 'block';
+        return;
+      }
+
+      saveNewCategoryBtn.disabled = true;
+      saveNewCategoryBtn.textContent = 'Creating…';
+
+      fetch('{% url "gift:create_category_ajax" wishlist.id %}', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+        },
+        body: JSON.stringify({name: name})
+      })
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        saveNewCategoryBtn.disabled = false;
+        saveNewCategoryBtn.textContent = 'Create Category';
+
+        if (data.status === 'success') {
+          var existingOption = categorySelect.querySelector('option[value="' + data.category_id + '"]');
+          if (!existingOption) {
+            var option = document.createElement('option');
+            option.value = data.category_id;
+            option.textContent = data.category_name;
+            categorySelect.appendChild(option);
+          }
+          categorySelect.value = data.category_id;
+          $('#newCategoryModal').modal('hide');
+        } else {
+          newCategoryError.textContent = data.message || 'Error creating category.';
+          newCategoryError.style.display = 'block';
+        }
+      })
+      .catch(function () {
+        saveNewCategoryBtn.disabled = false;
+        saveNewCategoryBtn.textContent = 'Create Category';
+        newCategoryError.textContent = 'An unexpected error occurred. Please try again.';
+        newCategoryError.style.display = 'block';
+      });
     });
   }
 })();

--- a/gift/templates/gift/wishlist_detail.html
+++ b/gift/templates/gift/wishlist_detail.html
@@ -1,4 +1,5 @@
 {% extends 'gift/base/base_generic.html' %}
+{% load gift_extras %}
 
 {% block content %}
 <div class="wl-page">
@@ -20,6 +21,11 @@
         {% if wishlist.description %}
         <p class="wl-page-subtitle">{{ wishlist.description }}</p>
         {% endif %}
+        {% with person=wishlist.dependent|default:wishlist.owner %}
+          {% if person.birthday %}
+          <p class="wl-page-subtitle">{{ person|birthday_label }}</p>
+          {% endif %}
+        {% endwith %}
         {% comment %}
            Progress — requires purchased_count and total_count in view context.
            Add to view: context['total_count'] and context['purchased_count']

--- a/gift/templates/gift/wishlist_edit.html
+++ b/gift/templates/gift/wishlist_edit.html
@@ -175,7 +175,7 @@
 <script>
     const { createApp, ref, computed, onMounted } = Vue;
 
-    createApp({
+    const app = createApp({
         setup() {
             // Initial Data Injection from Django
             // prettier-ignore
@@ -190,7 +190,6 @@
             url: `{{ form.url.value|default_if_none:''|escapejs }}`,
             purchased: {{ form.purchased.value|yesno:"true,false" }},
         category: `{{ form.category.value|default_if_none:''|escapejs }}`,
-        new_category_name: `{{ form.new_category_name.value|default_if_none:''|escapejs }}`,
         DELETE: {{ form.DELETE.value|yesno:"true,false" }},
         prefix: `{{ form.prefix }}`,
         errors: {
@@ -218,6 +217,7 @@
 
     const items = ref(initialForms);
     const isMobile = ref(window.innerWidth <= 768);
+    const pendingCategoryIndex = ref(null);
 
     // Responsive check
     window.addEventListener('resize', () => {
@@ -244,7 +244,6 @@
             url: '',
             purchased: false,
             category: '',
-            new_category_name: '',
             DELETE: false,
             prefix: `${formPrefix}-${newIndex}`,
             errors: {}
@@ -264,6 +263,27 @@
             // Let's just mark DELETE=true for simplicity and consistency.
             items.value[index].DELETE = true;
         }
+    };
+
+    const openNewCategoryModal = (index) => {
+        pendingCategoryIndex.value = index;
+        document.getElementById('newCategoryName').value = '';
+        document.getElementById('newCategoryError').style.display = 'none';
+        document.getElementById('newCategoryError').textContent = '';
+        $('#newCategoryModal').modal('show');
+        setTimeout(() => document.getElementById('newCategoryName').focus(), 200);
+    };
+
+    const addCategoryAndSelect = (categoryId, categoryName) => {
+        const strId = String(categoryId);
+        const exists = categoryOptions.value.some(opt => opt.value === strId);
+        if (!exists) {
+            categoryOptions.value.push({ value: strId, label: categoryName });
+        }
+        if (pendingCategoryIndex.value !== null && items.value[pendingCategoryIndex.value]) {
+            items.value[pendingCategoryIndex.value].category = strId;
+        }
+        pendingCategoryIndex.value = null;
     };
 
     onMounted(() => {
@@ -293,6 +313,8 @@
         items,
         addItem,
         removeItem,
+        openNewCategoryModal,
+        addCategoryAndSelect,
         isMobile,
         priceOptions,
         categoryOptions
@@ -356,13 +378,11 @@
                                 </td>
                                 {% if wishlist.family_name %}
                                 <td>
-                                    <select class="form-select form-select-sm mb-1" v-model="item.category" :name="item.prefix + '-category'">
-                                        <option v-for="opt in categoryOptions" :value="opt.value">{{ opt.label }}</option>
-                                    </select>
-                                    <div v-if="item.category === '__CREATE_NEW__'">
-                                        <input type="text" class="form-control form-control-sm" 
-                                               v-model="item.new_category_name" :name="item.prefix + '-new_category_name'"
-                                               placeholder="New Category Name">
+                                    <div style="display:flex;gap:6px;">
+                                        <select class="form-select form-select-sm mb-1" v-model="item.category" :name="item.prefix + '-category'" style="flex:1;">
+                                            <option v-for="opt in categoryOptions" :value="opt.value">{{ opt.label }}</option>
+                                        </select>
+                                        <button type="button" class="btn btn-outline-secondary btn-sm" @click="openNewCategoryModal(index)" title="New category" style="white-space:nowrap;">+ New</button>
                                     </div>
                                 </td>
                                 {% endif %}
@@ -426,13 +446,11 @@
                             {% if wishlist.family_name %}
                             <div class="mt-2 pt-2 border-top">
                                 <label class="form-label small text-muted mb-1">Category</label>
-                                <select class="form-select form-select-sm mb-1" v-model="item.category" :name="item.prefix + '-category'">
-                                    <option v-for="opt in categoryOptions" :value="opt.value">{{ opt.label }}</option>
-                                </select>
-                                <div v-if="item.category === '__CREATE_NEW__'">
-                                    <input type="text" class="form-control form-control-sm mt-1" 
-                                           v-model="item.new_category_name" :name="item.prefix + '-new_category_name'"
-                                           placeholder="Enter New Category Name">
+                                <div style="display:flex;gap:6px;">
+                                    <select class="form-select form-select-sm mb-1" v-model="item.category" :name="item.prefix + '-category'" style="flex:1;">
+                                        <option v-for="opt in categoryOptions" :value="opt.value">{{ opt.label }}</option>
+                                    </select>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" @click="openNewCategoryModal(index)" title="New category" style="white-space:nowrap;">+ New</button>
                                 </div>
                             </div>
                             {% endif %}
@@ -448,20 +466,102 @@
                 </div>
             </div>
         `
-    }).mount('#wishlist-edit-app');
+    const vm = app.mount('#wishlist-edit-app');
+    window.wlEditApp = vm;
 </script>
 
 <!-- Hidden source for categories -->
 <select id="category-source" style="display:none;">
+    <option value="">---------</option>
     {% if formset.empty_form.fields.category.queryset %}
     {% for category in formset.empty_form.fields.category.queryset %}
     <option value="{{ category.id }}">{{ category.name }}</option>
     {% endfor %}
     {% endif %}
-    <!-- Add special create new option manually as it might be added in init -->
-    <option value="__CREATE_NEW__">+ Create New Category</option>
-    <!-- Fallback if we want to show 'No Category' or similar -->
 </select>
+
+<!-- New Category Modal -->
+<div class="modal fade" id="newCategoryModal" tabindex="-1" role="dialog" aria-labelledby="newCategoryModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="newCategoryModalLabel">Create New Category</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label for="newCategoryName">Category Name</label>
+          <input type="text" class="form-control" id="newCategoryName" placeholder="e.g. Tech, Books, Clothing…">
+          <div class="text-danger" id="newCategoryError" style="display:none;margin-top:4px;"></div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="saveNewCategoryBtn">Create Category</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+    var saveBtn = document.getElementById('saveNewCategoryBtn');
+    var nameInput = document.getElementById('newCategoryName');
+    var errorDiv = document.getElementById('newCategoryError');
+
+    function getCsrfToken() {
+        var input = document.querySelector('#wishlist-form [name=csrfmiddlewaretoken]');
+        return input ? input.value : '';
+    }
+
+    if (saveBtn) {
+        saveBtn.addEventListener('click', function () {
+            var name = nameInput.value.trim();
+            if (!name) {
+                errorDiv.textContent = 'Please enter a category name.';
+                errorDiv.style.display = 'block';
+                return;
+            }
+
+            saveBtn.disabled = true;
+            saveBtn.textContent = 'Creating…';
+            errorDiv.style.display = 'none';
+
+            fetch('{% url "gift:create_category_ajax" wishlist.id %}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCsrfToken()
+                },
+                body: JSON.stringify({name: name})
+            })
+            .then(function (response) { return response.json(); })
+            .then(function (data) {
+                saveBtn.disabled = false;
+                saveBtn.textContent = 'Create Category';
+
+                if (data.status === 'success') {
+                    if (window.wlEditApp && window.wlEditApp.addCategoryAndSelect) {
+                        window.wlEditApp.addCategoryAndSelect(data.category_id, data.category_name);
+                    }
+                    $('#newCategoryModal').modal('hide');
+                } else {
+                    errorDiv.textContent = data.message || 'Error creating category.';
+                    errorDiv.style.display = 'block';
+                }
+            })
+            .catch(function () {
+                saveBtn.disabled = false;
+                saveBtn.textContent = 'Create Category';
+                errorDiv.textContent = 'An unexpected error occurred. Please try again.';
+                errorDiv.style.display = 'block';
+            });
+        });
+    }
+})();
+</script>
 
 <style>
     /* Styling Tweaks for Vue Components */

--- a/gift/templatetags/gift_extras.py
+++ b/gift/templatetags/gift_extras.py
@@ -1,0 +1,19 @@
+"""Custom template filters for the gift app."""
+from datetime import date
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def birthday_label(user):
+    """Return a friendly birthday label for a WikiUser, e.g. '01/15 (age 8)'."""
+    if not user or not user.birthday:
+        return ''
+    birthday = user.birthday
+    today = date.today()
+    age = today.year - birthday.year - (
+        (today.month, today.day) < (birthday.month, birthday.day)
+    )
+    return f"{birthday.month}/{birthday.day} (age {age})"

--- a/gift/urls.py
+++ b/gift/urls.py
@@ -36,6 +36,11 @@ urlpatterns = [
     path('item/purchase/<int:item_id>/', views.item_purchase, name='purchase_item'),
     # Categories
     path('category/edit/<int:category_id>/', views.category_edit, name='edit_category'),
+    path(
+        'wishlist/<int:wishlist_id>/category/create/',
+        views.category_create_ajax,
+        name='create_category_ajax',
+    ),
     # Public pages (no auth required)
     path('privacy/', views.privacy_view, name='privacy'),
     path('data-deletion/', views.data_deletion_view, name='data_deletion'),

--- a/gift/views.py
+++ b/gift/views.py
@@ -955,7 +955,7 @@ def home(request):
                     current_grouping = 'house'
 
         # Optimize query with select_related
-        wishlists = WishList.objects.select_related('family_name', 'owner').all()
+        wishlists = WishList.objects.select_related('family_name', 'owner', 'dependent').all()
         wishlists_grouped = defaultdict(list)
         strategy = strategies[current_grouping]
 
@@ -1145,32 +1145,8 @@ def wishlist_edit(request, wishlist_id):
 
                     # Handle category assignment
                     category = form.cleaned_data.get('category')
-                    new_category_name = form.cleaned_data.get('new_category_name')
                     instance.categories.clear()
-
-                    # Handle "Create new..." option
-                    if category == '__CREATE_NEW__':
-                        if new_category_name and wishlist.family_name:
-                            from .models import Category
-
-                            category_obj, created = Category.objects.get_or_create(
-                                name=new_category_name,
-                                family=wishlist.family_name,
-                                defaults={'description': f'Category for {new_category_name}'},
-                            )
-                            instance.categories.add(category_obj)
-                    elif new_category_name and wishlist.family_name:
-                        # If new category name provided, create it (takes precedence over selected category)
-                        from .models import Category
-
-                        category_obj, created = Category.objects.get_or_create(
-                            name=new_category_name,
-                            family=wishlist.family_name,
-                            defaults={'description': f'Category for {new_category_name}'},
-                        )
-                        instance.categories.add(category_obj)
-                    elif category and category != '__CREATE_NEW__':
-                        # Use the selected existing category
+                    if category:
                         instance.categories.add(category)
 
             messages.success(request, 'Wishlist and items updated successfully.')
@@ -1307,4 +1283,74 @@ def category_edit(request, category_id):
         request,
         'gift/category_edit.html',
         {'form': form, 'category': category, 'wishlist': wishlist},
+    )
+
+
+@require_POST
+@login_required
+def category_create_ajax(request, wishlist_id):
+    """Create a new category for a wishlist's family via AJAX.
+
+    Returns JSON with the created category's id and name so the caller
+    can update its dropdown without reloading the page.
+    """
+    wishlist = get_object_or_404(WishList, id=wishlist_id)
+
+    # Permission check: owner, dependent (steward), or manager
+    is_owner = request.user == wishlist.owner or request.user == wishlist.dependent
+    is_manager = request.user in wishlist.managers.all()
+    from giftwiki.feature_flags import get_steward_proxy_enabled
+
+    STEWARD_PROXY_ENABLED = get_steward_proxy_enabled()
+    is_steward = STEWARD_PROXY_ENABLED and request.user == wishlist.dependent
+
+    if not (is_owner or is_manager or is_steward):
+        logger.warning(
+            'Unauthorized category creation attempt',
+            extra={'wishlist_id': wishlist_id, 'user': request.user.email},
+        )
+        return JsonResponse({'status': 'error', 'message': 'Permission denied'}, status=403)
+
+    if not wishlist.family_name:
+        return JsonResponse(
+            {'status': 'error', 'message': 'This wishlist does not have a family assigned.'},
+            status=400,
+        )
+
+    try:
+        data = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({'status': 'error', 'message': 'Invalid JSON body'}, status=400)
+
+    name = data.get('name', '').strip()
+    if not name:
+        return JsonResponse(
+            {'status': 'error', 'message': 'Category name is required.'}, status=400
+        )
+
+    category, created = Category.objects.get_or_create(
+        family=wishlist.family_name,
+        name=name,
+        defaults={'description': f'Category for {name}'},
+    )
+
+    if created:
+        logger.info(
+            'Category created via AJAX',
+            extra={
+                'category_id': category.id,
+                'category_name': category.name,
+                'family_id': wishlist.family_name_id,
+                'wishlist_id': wishlist.id,
+                'user': request.user.email,
+            },
+        )
+
+    return JsonResponse(
+        {
+            'status': 'success',
+            'category_id': category.id,
+            'category_name': category.name,
+            'created': created,
+        }
     )

--- a/tests/api/test_birthday_display.py
+++ b/tests/api/test_birthday_display.py
@@ -1,0 +1,54 @@
+"""Tests for birthday display on wishlist list and detail pages."""
+import pytest
+from django.contrib.auth import get_user_model
+
+from gift.models import Family, WishList
+
+User = get_user_model()
+
+
+@pytest.mark.unit
+class TestBirthdayDisplay:
+    def test_home_page_shows_birthday(self, authenticated_user, user):
+        """The home page shows the list owner's birthday."""
+        family = Family.objects.create(name='Birthday Family')
+        user.birthday = '1990-03-15'
+        user.save()
+        WishList.objects.create(owner=user, title='Birthday List', family_name=family)
+
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert '3/15' in content
+        assert '(age' in content
+
+    def test_home_page_shows_dependent_birthday(self, authenticated_user, user):
+        """The home page shows the dependent's birthday when present."""
+        family = Family.objects.create(name='Dependent Family')
+        dependent = User.objects.create_user(
+            username='kid', birthday='2015-07-20', email='kid@example.com'
+        )
+        WishList.objects.create(
+            owner=user, dependent=dependent, title='Kid List', family_name=family
+        )
+
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert '7/20' in content
+        assert '(age' in content
+
+    def test_wishlist_detail_shows_birthday(self, authenticated_user, user):
+        """The wishlist detail page shows the person's birthday."""
+        family = Family.objects.create(name='Detail Family')
+        user.birthday = '1985-12-25'
+        user.save()
+        wishlist = WishList.objects.create(
+            owner=user, title='Detail List', family_name=family
+        )
+
+        response = authenticated_user.get(f'/wishlist/{wishlist.id}/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert '12/25' in content
+        assert '(age' in content

--- a/tests/api/test_category_bug.py
+++ b/tests/api/test_category_bug.py
@@ -1,0 +1,62 @@
+"""Tests for category creation via modal/AJAX and item assignment."""
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from gift.models import Category, Family, Item, WishList
+
+User = get_user_model()
+
+
+@pytest.mark.unit
+class TestCategoryCreation:
+    def test_create_category_via_ajax(self, authenticated_user, user):
+        """A manager can create a category via AJAX and it appears in the response."""
+        family = Family.objects.create(name='Ajax Family')
+        wishlist = WishList.objects.create(owner=user, title='Ajax List', family_name=family)
+
+        response = authenticated_user.post(
+            f'/wishlist/{wishlist.id}/category/create/',
+            data=json.dumps({'name': 'New Ajax Category'}),
+            content_type='application/json',
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data['status'] == 'success'
+        assert data['category_name'] == 'New Ajax Category'
+        assert Category.objects.filter(family=family, name='New Ajax Category').exists()
+
+    def test_add_item_with_existing_category(self, authenticated_user, user):
+        """After creating a category, an item can be saved with that category selected."""
+        family = Family.objects.create(name='Item Family')
+        wishlist = WishList.objects.create(owner=user, title='Item List', family_name=family)
+        category = Category.objects.create(family=family, name='Existing Category')
+
+        data = {
+            'name': 'Categorized Item',
+            'description': '',
+            'price': '',
+            'price_range': '',
+            'url': '',
+            'category': category.id,
+        }
+        response = authenticated_user.post(f'/wishlist/{wishlist.id}/add_item/', data)
+        assert response.status_code == 302
+        item = Item.objects.get(name='Categorized Item')
+        assert item.categories.filter(name='Existing Category').exists()
+
+    def test_non_manager_cannot_create_category_via_ajax(
+        self, authenticated_other_user, user
+    ):
+        """A user who does not manage the wishlist cannot create a category."""
+        family = Family.objects.create(name='Protected Family')
+        wishlist = WishList.objects.create(owner=user, title='Protected List', family_name=family)
+
+        response = authenticated_other_user.post(
+            f'/wishlist/{wishlist.id}/category/create/',
+            data=json.dumps({'name': 'Hacker Category'}),
+            content_type='application/json',
+        )
+        assert response.status_code == 403
+        assert not Category.objects.filter(family=family, name='Hacker Category').exists()


### PR DESCRIPTION
Implements feedback from family chat:

- Shows birth date (with age) on the home wishlist list and on each individual wishlist detail page.
- Fixes the category creation bug that threw an error when creating a new category while saving an item.
- Replaces the inline "+ Create New Category" dropdown option with a Bootstrap modal that creates the category via AJAX and updates the dropdown.