### PR TITLE
fix: use Bootstrap 4 sr-only class for spinner loading text

### DIFF
--- a/gift/templates/gift/wishlist_edit.html
+++ b/gift/templates/gift/wishlist_edit.html
@@ -147,7 +147,7 @@
                 <div id="wishlist-edit-app">
                     <div class="d-flex justify-content-center p-5">
                         <div class="spinner-border text-primary" role="status">
-                            <span class="visually-hidden">Loading...</span>
+                            <span class="sr-only">Loading...</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Replaces 'visually-hidden' (Bootstrap 5) with 'sr-only' (Bootstrap 4.3) in the wishlist edit loading spinner so the loading text is hidden properly and letters are not stacked vertically inside the spinner.