### PR TITLE
feat: make purchased-by badge anonymous by default with reveal toggle

### DIFF
--- a/gift/static/css/custom.css
+++ b/gift/static/css/custom.css
@@ -412,6 +412,42 @@ label { font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bo
 .text-muted { color: var(--text-muted) !important; }
 .text-secondary { color: var(--text-secondary) !important; }
 
+/* ── PURCHASER ANONYMITY TOGGLE ─────────────────────────── */
+.purchased-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.purchaser-name {
+  display: none;
+}
+.purchaser-name.is-visible {
+  display: inline;
+}
+.reveal-purchaser {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0 0 0 2px;
+  color: var(--text-muted);
+  cursor: pointer;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}
+.reveal-purchaser:hover {
+  color: var(--text-secondary);
+}
+.reveal-purchaser .eye-closed {
+  display: none;
+}
+.reveal-purchaser.is-revealed .eye-open {
+  display: none;
+}
+.reveal-purchaser.is-revealed .eye-closed {
+  display: inline;
+}
+
 /* ── RESPONSIVE ─────────────────────────────────────────── */
 @media (max-width: 767px) {
   .wl-nav-links { display: none; }

--- a/gift/templates/gift/wishlist_detail.html
+++ b/gift/templates/gift/wishlist_detail.html
@@ -95,7 +95,22 @@
             {% endif %}
             {% if not is_list_manager and item.purchased %}
               {% if item.purchased_by %}
-                <span class="badge badge-success">Purchased by {{ item.purchased_by.get_full_name|default:item.purchased_by.username }}</span>
+                <span class="badge badge-success purchased-badge">
+                  Purchased
+                  <span class="purchaser-name" style="display: none;">
+                    by {{ item.purchased_by.get_full_name|default:item.purchased_by.username }}
+                  </span>
+                </span>
+                <button type="button" class="reveal-purchaser" title="Show who purchased this" aria-label="Show who purchased this">
+                  <svg class="eye-open" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                    <circle cx="12" cy="12" r="3"/>
+                  </svg>
+                  <svg class="eye-closed" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/>
+                    <line x1="1" y1="1" x2="23" y2="23"/>
+                  </svg>
+                </button>
               {% else %}
                 <span class="badge badge-success">Purchased</span>
               {% endif %}
@@ -173,7 +188,22 @@
             {% endif %}
             {% if not is_list_manager and item.purchased %}
               {% if item.purchased_by %}
-                <span class="badge badge-success">Purchased by {{ item.purchased_by.get_full_name|default:item.purchased_by.username }}</span>
+                <span class="badge badge-success purchased-badge">
+                  Purchased
+                  <span class="purchaser-name" style="display: none;">
+                    by {{ item.purchased_by.get_full_name|default:item.purchased_by.username }}
+                  </span>
+                </span>
+                <button type="button" class="reveal-purchaser" title="Show who purchased this" aria-label="Show who purchased this">
+                  <svg class="eye-open" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                    <circle cx="12" cy="12" r="3"/>
+                  </svg>
+                  <svg class="eye-closed" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/>
+                    <line x1="1" y1="1" x2="23" y2="23"/>
+                  </svg>
+                </button>
               {% else %}
                 <span class="badge badge-success">Purchased</span>
               {% endif %}
@@ -271,5 +301,35 @@
 })();
 </script>
 {% endif %}
+
+<script>
+(function () {
+  const STORAGE_KEY = 'giftwiki_reveal_purchaser';
+
+  function setAll(show) {
+    document.querySelectorAll('.purchaser-name').forEach(function (el) {
+      el.classList.toggle('is-visible', show);
+    });
+    document.querySelectorAll('.reveal-purchaser').forEach(function (btn) {
+      btn.classList.toggle('is-revealed', show);
+      const label = show ? 'Hide who purchased this' : 'Show who purchased this';
+      btn.title = label;
+      btn.setAttribute('aria-label', label);
+    });
+    localStorage.setItem(STORAGE_KEY, show ? 'true' : 'false');
+  }
+
+  document.querySelectorAll('.reveal-purchaser').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      const anyHidden = document.querySelector('.purchaser-name:not(.is-visible)');
+      setAll(Boolean(anyHidden));
+    });
+  });
+
+  if (localStorage.getItem(STORAGE_KEY) === 'true') {
+    setAll(true);
+  }
+})();
+</script>
 
 {% endblock %}

--- a/gift/templates/gift/wishlist_detail.html
+++ b/gift/templates/gift/wishlist_detail.html
@@ -97,7 +97,7 @@
               {% if item.purchased_by %}
                 <span class="badge badge-success purchased-badge">
                   Purchased
-                  <span class="purchaser-name" style="display: none;">
+                  <span class="purchaser-name">
                     by {{ item.purchased_by.get_full_name|default:item.purchased_by.username }}
                   </span>
                 </span>
@@ -190,7 +190,7 @@
               {% if item.purchased_by %}
                 <span class="badge badge-success purchased-badge">
                   Purchased
-                  <span class="purchaser-name" style="display: none;">
+                  <span class="purchaser-name">
                     by {{ item.purchased_by.get_full_name|default:item.purchased_by.username }}
                   </span>
                 </span>

--- a/tests/features/purchase.feature
+++ b/tests/features/purchase.feature
@@ -1,9 +1,10 @@
 Feature: Wishlist item purchase rules
   Anyone on the family can mark a wishlist item as purchased except the
   list's owner or managers (no spoilers). A purchaser may toggle their
-  own purchase back off. Once an item is purchased, nobody else may
-  overwrite that purchase. The "Purchased by" badge is shown to everyone
-  on the list except the list owner/managers.
+  own purchase back off. Once an item is purchased, it is shown as
+  "Purchased" anonymously by default; a reveal control lets curious
+  viewers see who purchased it. List owners/managers see no purchase
+  information at all.
 
   Scenario: Non-owner can mark an item as purchased
     Given a wishlist with an unpurchased item
@@ -27,14 +28,16 @@ Feature: Wishlist item purchase rules
     When a third user tries to mark the item as purchased
     Then the item is marked purchased by the other user
 
-  Scenario: Purchase status is visible to non-owners
+  Scenario: Purchased status is anonymous by default for non-owners
     Given a wishlist with an unpurchased item
     And the other user has already purchased the item
     When a third user views the wishlist page
-    Then the page shows "Purchased by"
+    Then the page shows "Purchased" anonymously
+    And the page hides the purchaser name by default
+    And the page has a reveal purchaser control
 
-  Scenario: Purchase status is hidden from the list owner
+  Scenario: Purchase information is hidden from the list owner
     Given a wishlist with an unpurchased item
     And the other user has already purchased the item
     When the owner views the wishlist page
-    Then the page does not show "Purchased by"
+    Then the page does not show purchase information

--- a/tests/steps/test_purchase.py
+++ b/tests/steps/test_purchase.py
@@ -99,11 +99,14 @@ def page_shows_purchased_anonymous(wishlist_response):
 @then('the page hides the purchaser name by default')
 def page_hides_purchaser_name(wishlist_response):
     content = wishlist_response.content.decode()
+    # The purchaser name is hidden by the .purchaser-name CSS rule by default;
+    # verify the span exists and is not marked as visible.
     match = re.search(
-        r'<span[^>]*class="[^"]*purchaser-name[^"]*"[^>]*style="[^"]*display:\s*none[^"]*"[^>]*>',
+        r'<span[^>]*class="[^"]*purchaser-name[^"]*"[^>]*>',
         content,
     )
-    assert match, 'purchaser-name span is not hidden by default'
+    assert match, 'purchaser-name span is missing'
+    assert 'purchaser-name is-visible' not in content, 'purchaser-name span is visible by default'
 
 
 @then('the page has a reveal purchaser control')

--- a/tests/steps/test_purchase.py
+++ b/tests/steps/test_purchase.py
@@ -6,6 +6,7 @@ Scenarios live in ../features/purchase.feature. Fixtures (``user``,
 ``third_user`` fixture covers the "already-purchased" spoiler scenarios.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -87,13 +88,34 @@ def assert_unpurchased(purchase_item):
     assert purchase_item.purchased_by is None
 
 
-@then('the page shows "Purchased by"')
-def page_shows_purchased_by(wishlist_response):
+@then('the page shows "Purchased" anonymously')
+def page_shows_purchased_anonymous(wishlist_response):
     assert wishlist_response.status_code == 200
-    assert 'Purchased by' in wishlist_response.content.decode()
+    content = wishlist_response.content.decode()
+    assert 'purchased-badge' in content
+    assert 'purchaser-name' in content
 
 
-@then('the page does not show "Purchased by"')
-def page_hides_purchased_by(wishlist_response):
+@then('the page hides the purchaser name by default')
+def page_hides_purchaser_name(wishlist_response):
+    content = wishlist_response.content.decode()
+    match = re.search(
+        r'<span[^>]*class="[^"]*purchaser-name[^"]*"[^>]*style="[^"]*display:\s*none[^"]*"[^>]*>',
+        content,
+    )
+    assert match, 'purchaser-name span is not hidden by default'
+
+
+@then('the page has a reveal purchaser control')
+def page_has_reveal_control(wishlist_response):
+    content = wishlist_response.content.decode()
+    assert 'reveal-purchaser' in content
+
+
+@then('the page does not show purchase information')
+def page_hides_purchase_info(wishlist_response):
     assert wishlist_response.status_code == 200
-    assert 'Purchased by' not in wishlist_response.content.decode()
+    content = wishlist_response.content.decode()
+    # The purchased badge markup is not rendered for owners; use a class that
+    # only appears in the actual badge HTML, not in the reveal script.
+    assert 'purchased-badge' not in content


### PR DESCRIPTION
Purchased items now display a generic "Purchased" badge. A small eye-icon
button next to the badge reveals the purchaser's name for curious viewers.
The reveal preference is remembered per-browser via localStorage. List
owners/managers continue to see no purchase information at all.

- update wishlist_detail template with anonymous badge + reveal control
- add purchaser-toggle styles to custom.css
- update purchase.feature BDD tests for anonymous default behavior
