### PR TITLE
fix: add CONN_HEALTH_CHECKS for Neon SSL connection drops

### DIFF
--- a/giftwiki/settings.py
+++ b/giftwiki/settings.py
@@ -232,6 +232,9 @@ if os.getenv('DJANGO_DB_HOST'):
             'CONN_MAX_AGE': int(
                 os.getenv('DJANGO_DB_CONN_MAX_AGE', '0')
             ),  # 0 for serverless/Cloud Run to avoid closed connection errors
+            # Validate pooled connections before reuse, so Neon dropping idle SSL
+            # connections doesn't surface as request errors when CONN_MAX_AGE > 0.
+            'CONN_HEALTH_CHECKS': os.getenv('DJANGO_DB_CONN_HEALTH_CHECKS', 'True') == 'True',
         }
     }
 else:


### PR DESCRIPTION
Closes #12.

Adds `CONN_HEALTH_CHECKS` to the PostgreSQL/Neon branch of `giftwiki/settings.py` (env-tunable via `DJANGO_DB_CONN_HEALTH_CHECKS`, default `True`). Django validates pooled connections before reuse, so idle SSL connections dropped by Neon won't surface as request errors once `CONN_MAX_AGE` is raised above 0.

No behavior change with the current `CONN_MAX_AGE=0` (connections aren't pooled), so this is safe to ship ahead of any pooling tuning. Verified: settings load with the Postgres branch active, full suite (68 tests) green, ruff clean.