### PR TITLE
feat: add My Purchases page for givers

### DIFF
--- a/gift/templates/gift/base/base_generic.html
+++ b/gift/templates/gift/base/base_generic.html
@@ -46,6 +46,8 @@
         {% if request.user.is_authenticated %}
         <a class="wl-nav-link {% if request.resolver_match.url_name == 'account' %}active{% endif %}"
            href="{% url 'gift:account' %}">My Lists</a>
+        <a class="wl-nav-link {% if request.resolver_match.url_name == 'my_purchases' %}active{% endif %}"
+           href="{% url 'gift:my_purchases' %}">My Purchases</a>
         {% endif %}
       </div>
 

--- a/gift/templates/gift/my_purchases.html
+++ b/gift/templates/gift/my_purchases.html
@@ -1,0 +1,91 @@
+{% extends 'gift/base/base_generic.html' %}
+
+{% block content %}
+<div class="wl-page">
+
+  {# Back link #}
+  <a class="wl-back" href="{% url 'gift:home' %}">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M19 12H5"/><polyline points="12 19 5 12 12 5"/>
+    </svg>
+    All Lists
+  </a>
+
+  {# Page header #}
+  <div class="wl-page-header">
+    <div class="wl-page-header-row">
+      <div>
+        <h1 class="wl-page-title">My Purchases</h1>
+        <p class="wl-page-subtitle">Everything you've marked as purchased, grouped by list.</p>
+        {% if total_count %}
+        <div class="wl-progress">
+          <span class="wl-progress-label">
+            <span class="wl-progress-mono">{{ total_count }}</span>
+            item{{ total_count|pluralize }} purchased &middot;
+            total spend <span class="wl-progress-mono">${{ total_spend|floatformat:2 }}</span>
+          </span>
+        </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  {# Purchases grouped by wishlist #}
+  {% if purchases_by_wishlist %}
+
+    {% for wishlist, items in purchases_by_wishlist %}
+    <div class="wl-cat-section">
+      <div class="wl-cat-header">
+        <span class="wl-cat-label">
+          {{ wishlist.title }} &middot;
+          {% with person=wishlist.dependent|default:wishlist.owner %}
+            {{ person.get_full_name|default:person.username }}
+          {% endwith %}
+        </span>
+        <span class="wl-count-badge">{{ items|length }}</span>
+      </div>
+
+      {% for item in items %}
+      <a class="wl-item-row" href="{% url 'gift:wishlist_detail' wishlist.id %}"
+         style="text-decoration:none;color:inherit;">
+        <div class="wl-item-main">
+          <div class="wl-item-name">
+            <span>{{ item.name }}</span>
+            {% if item.price %}
+              <span class="badge-price">${{ item.price|floatformat:2 }}</span>
+            {% elif item.price_range %}
+              <span class="badge-price">{{ item.get_price_range_display }}</span>
+            {% endif %}
+          </div>
+          {% if item.description %}
+          <div class="wl-item-desc">{{ item.description|safe }}</div>
+          {% endif %}
+        </div>
+
+        <div class="wl-item-actions">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2"
+               stroke-linecap="round" stroke-linejoin="round"
+               style="color:var(--text-muted);flex-shrink:0;">
+            <polyline points="9 18 15 12 9 6"/>
+          </svg>
+        </div>
+      </a>
+      {% endfor %}
+
+    </div>
+    {% endfor %}
+
+  {% else %}
+
+    <div style="text-align:center;padding:56px 24px;color:var(--text-muted);">
+      <p style="font-size:15px;font-weight:600;color:var(--text-secondary);margin-bottom:6px;">You haven't marked anything as purchased yet</p>
+      <p style="font-size:13px;margin-bottom:20px;">Browse your family's wishlists and tap "Mark Purchased" on anything you buy.</p>
+      <a href="{% url 'gift:home' %}" class="btn btn-primary">Browse Wishlists</a>
+    </div>
+
+  {% endif %}
+
+</div>
+{% endblock %}

--- a/gift/urls.py
+++ b/gift/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     # Authentication
     # Signup removed - users are auto-created via Traefik forward auth
     path('profile/', views.profile, name='account'),
+    path('my-purchases/', views.my_purchases, name='my_purchases'),
     path('select-scraped-page/', views.select_scraped_page, name='select_scraped_page'),
     path('logout/', views.logout_view, name='logout'),
     path('accounts/logout/', views.logout_view),  # Override Django's default POST-only logout

--- a/gift/views.py
+++ b/gift/views.py
@@ -1052,6 +1052,35 @@ def wishlist_detail(request, wishlist_id):
 
 
 @login_required
+def my_purchases(request):
+    """Show every item the current user has marked as purchased, grouped by wishlist."""
+    from decimal import Decimal
+
+    items = (
+        Item.objects.filter(purchased_by=request.user, is_deleted=False)
+        .select_related('wishlist', 'wishlist__owner', 'wishlist__dependent')
+        .order_by('-updated_at')
+    )
+
+    # Group by wishlist. Items are ordered most-recently-updated first, so groups
+    # are headed by the wishlist with the most recent purchase and items within
+    # each group are most recent first as well.
+    purchases_by_wishlist = defaultdict(list)
+    total_spend = Decimal('0.00')
+    for item in items:
+        purchases_by_wishlist[item.wishlist].append(item)
+        if item.price is not None:
+            total_spend += item.price
+
+    context = {
+        'purchases_by_wishlist': purchases_by_wishlist.items(),
+        'total_spend': total_spend,
+        'total_count': len(items),
+    }
+    return render(request, 'gift/my_purchases.html', context)
+
+
+@login_required
 def wishlist_edit(request, wishlist_id):
     wishlist = get_object_or_404(WishList, id=wishlist_id)
 

--- a/tests/api/test_my_purchases.py
+++ b/tests/api/test_my_purchases.py
@@ -1,0 +1,165 @@
+"""
+Tests for the "My purchases" page: a giver's own cross-wishlist purchase history.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from gift.models import Item, WishList
+
+User = get_user_model()
+
+
+@pytest.fixture
+def other_wishlist(db, other_user, family):
+    """A wishlist owned by other_user — somewhere `user` can buy gifts from."""
+    return WishList.objects.create(
+        owner=other_user,
+        title='Other User Wishlist',
+        description='Wishlist owned by the other user',
+        family_name=family,
+    )
+
+
+@pytest.mark.unit
+class TestMyPurchasesView:
+    """Test the my_purchases view."""
+
+    def test_requires_login(self, client):
+        """Unauthenticated users are redirected to the login page."""
+        response = client.get('/my-purchases/')
+        assert response.status_code == 302
+        assert response.url.startswith('/auth.html')
+
+    def test_empty_state(self, authenticated_user):
+        """A friendly empty state is shown when the user has no purchases."""
+        response = authenticated_user.get('/my-purchases/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "You haven't marked anything as purchased yet" in content
+        assert 'Browse Wishlists' in content
+
+    def test_only_own_purchases_appear(
+        self, authenticated_user, user, other_user, wishlist, other_wishlist
+    ):
+        """The page lists items the current user purchased, and nothing else."""
+        Item.objects.create(
+            wishlist=other_wishlist,
+            name='Bought By Me',
+            purchased=True,
+            purchased_by=user,
+            price='10.00',
+        )
+        Item.objects.create(
+            wishlist=wishlist,
+            name='Bought By Someone Else',
+            purchased=True,
+            purchased_by=other_user,
+            price='5.00',
+        )
+
+        response = authenticated_user.get('/my-purchases/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'Bought By Me' in content
+        assert 'Bought By Someone Else' not in content
+
+    def test_other_users_purchases_not_shown(
+        self, authenticated_other_user, user, other_user, wishlist, other_wishlist
+    ):
+        """The reverse direction: other_user must not see user's purchases."""
+        Item.objects.create(
+            wishlist=other_wishlist,
+            name='Bought By Me',
+            purchased=True,
+            purchased_by=user,
+            price='10.00',
+        )
+        Item.objects.create(
+            wishlist=wishlist,
+            name='Bought By Other',
+            purchased=True,
+            purchased_by=other_user,
+            price='5.00',
+        )
+
+        response = authenticated_other_user.get('/my-purchases/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'Bought By Other' in content
+        assert 'Bought By Me' not in content
+
+    def test_soft_deleted_items_excluded(self, authenticated_user, user, other_wishlist):
+        """Soft-deleted items never show up, even if the user bought them."""
+        Item.objects.create(
+            wishlist=other_wishlist,
+            name='Deleted Purchase',
+            purchased=True,
+            purchased_by=user,
+            is_deleted=True,
+            price='12.00',
+        )
+
+        response = authenticated_user.get('/my-purchases/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'Deleted Purchase' not in content
+        assert "You haven't marked anything as purchased yet" in content
+
+    def test_total_spend_sums_priced_items(self, authenticated_user, user, other_wishlist):
+        """Total spend sums priced items only; unpriced items still list."""
+        Item.objects.create(
+            wishlist=other_wishlist, name='Priced One', purchased=True,
+            purchased_by=user, price='10.00',
+        )
+        Item.objects.create(
+            wishlist=other_wishlist, name='Priced Two', purchased=True,
+            purchased_by=user, price='29.99',
+        )
+        Item.objects.create(
+            wishlist=other_wishlist, name='Unpriced', purchased=True, purchased_by=user,
+        )
+
+        response = authenticated_user.get('/my-purchases/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert '$39.99' in content
+        assert 'Unpriced' in content
+        # All 3 purchased items are counted
+        assert '<span class="wl-progress-mono">3</span>' in content
+
+    def test_grouped_by_wishlist_with_owner_and_links(
+        self, authenticated_user, user, wishlist, other_wishlist
+    ):
+        """Purchases are grouped under wishlist title + owner, linking to the list."""
+        Item.objects.create(
+            wishlist=wishlist, name='Item A', purchased=True, purchased_by=user,
+        )
+        Item.objects.create(
+            wishlist=other_wishlist, name='Item B', purchased=True, purchased_by=user,
+        )
+
+        response = authenticated_user.get('/my-purchases/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        # Group headers show wishlist titles and owner display names
+        assert 'Test Wishlist' in content
+        assert 'Other User Wishlist' in content
+        assert 'otheruser' in content
+        # Items link back to their wishlist detail pages
+        assert f'/wishlist/{wishlist.id}/' in content
+        assert f'/wishlist/{other_wishlist.id}/' in content
+
+    def test_most_recent_first_within_group(self, authenticated_user, user, other_wishlist):
+        """Within a wishlist group, most recently updated purchases come first."""
+        Item.objects.create(
+            wishlist=other_wishlist, name='Older Purchase', purchased=True, purchased_by=user,
+        )
+        Item.objects.create(
+            wishlist=other_wishlist, name='Newer Purchase', purchased=True, purchased_by=user,
+        )
+
+        response = authenticated_user.get('/my-purchases/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert content.index('Newer Purchase') < content.index('Older Purchase')


### PR DESCRIPTION
Closes #6.

Givers can now see everything they've marked as purchased across all wishlists:

- New **/my-purchases/** page (nav link next to "My Lists", authenticated users only): items grouped by wishlist (title + owner), most recent first, with per-item price (or price-range fallback), a total-spend summary, links back to each wishlist, and a friendly empty state.
- Privacy by construction: the queryset is scoped to `purchased_by=request.user` — no other purchaser's data is ever fetched. Owner-blindness on wishlist detail pages is unchanged.
- Mobile-friendly: reuses the existing design-system classes (`wl-item-row` full-row anchors as large tap targets).

Tests: +8 (`tests/api/test_my_purchases.py`) — auth redirect, empty state, own-vs-others visibility both directions, soft-deleted excluded, total spend, grouping/order. Full suite 76 passed; ruff clean.