### PR TITLE
feat: upcoming birthdays section on the home page

### DIFF
--- a/gift/templates/gift/home.html
+++ b/gift/templates/gift/home.html
@@ -48,6 +48,59 @@
       </div>
     </div>
 
+    {% if upcoming_birthdays %}
+    <div class="wl-family-section">
+
+      <div class="wl-family-header">
+        <span class="wl-family-label">🎂 Upcoming Birthdays</span>
+        <span class="wl-count-badge">{{ upcoming_birthdays|length }}</span>
+      </div>
+
+      <div>
+        {% for entry in upcoming_birthdays %}
+          {% if entry.wishlist_id %}
+          <a class="wl-list-row" href="{% url 'gift:wishlist_detail' entry.wishlist_id %}">
+          {% else %}
+          <div class="wl-list-row">
+          {% endif %}
+
+            <div class="wl-list-row-info">
+              <div class="wl-list-avatar">
+                {% if entry.user.first_name %}
+                  {{ entry.user.first_name|slice:":1"|upper }}{{ entry.user.last_name|slice:":1"|upper }}
+                {% else %}
+                  {{ entry.user.username|slice:":2"|upper }}
+                {% endif %}
+              </div>
+              <div>
+                <div class="wl-list-title">{{ entry.user.get_full_name|default:entry.user.username }}</div>
+                <div class="wl-list-birthday">{{ entry.user.birthday|date:"M j" }} · turns {{ entry.turning_age }}</div>
+              </div>
+            </div>
+
+            <div class="wl-list-row-right">
+              <span class="wl-list-meta">{% if entry.days_until == 0 %}today! 🎉{% else %}in {{ entry.days_until }} day{{ entry.days_until|pluralize }}{% endif %}</span>
+              {% if entry.wishlist_id %}
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2"
+                   stroke-linecap="round" stroke-linejoin="round"
+                   style="color:var(--text-muted);flex-shrink:0;">
+                <polyline points="9 18 15 12 9 6"/>
+              </svg>
+              {% endif %}
+            </div>
+
+          {% if entry.wishlist_id %}
+          </a>
+          {% else %}
+          </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+
+    </div>
+    {% endif %}
+
     {% for group_name, wishlists in wishlists_grouped.items %}
     <div class="wl-family-section">
 

--- a/gift/views.py
+++ b/gift/views.py
@@ -3,6 +3,7 @@ import logging
 import secrets
 import string
 from collections import defaultdict
+from datetime import date
 
 from django.conf import settings
 from django.contrib import messages
@@ -915,11 +916,73 @@ def get_grouping_strategies(seasons, request_user):
 
     return strategies
 
+
+def get_upcoming_birthdays(limit=5):
+    """
+    Return the next `limit` upcoming birthdays across all users with a birthday set
+    (managed/kid accounts are WikiUser rows, so they're included automatically),
+    ordered by days until the next occurrence. Today's birthday counts as upcoming
+    (days_until=0). Each entry is a dict with 'user', 'days_until', 'turning_age'
+    and 'wishlist_id' (None when the person has no wishlist to link to).
+    """
+    today = date.today()
+
+    def next_occurrence(birthday):
+        try:
+            next_birthday = birthday.replace(year=today.year)
+        except ValueError:
+            # Feb 29 birthdays are observed on Feb 28 in non-leap years
+            next_birthday = birthday.replace(year=today.year, day=28)
+        if next_birthday < today:
+            try:
+                next_birthday = birthday.replace(year=today.year + 1)
+            except ValueError:
+                next_birthday = birthday.replace(year=today.year + 1, day=28)
+        return next_birthday
+
+    upcoming = []
+    for user in User.objects.filter(birthday__isnull=False):
+        next_birthday = next_occurrence(user.birthday)
+        upcoming.append(
+            {
+                'user': user,
+                'days_until': (next_birthday - today).days,
+                'turning_age': next_birthday.year - user.birthday.year,
+                'wishlist_id': None,
+            }
+        )
+
+    upcoming.sort(key=lambda entry: (entry['days_until'], entry['user'].username))
+    upcoming = upcoming[:limit]
+
+    # Link each person to their most recently updated wishlist, using the same
+    # "person of the list" convention as the directory (dependent, else owner).
+    person_ids = {entry['user'].id for entry in upcoming}
+    if person_ids:
+        candidate_lists = (
+            WishList.objects.filter(
+                models.Q(owner_id__in=person_ids) | models.Q(dependent_id__in=person_ids)
+            )
+            .select_related('owner', 'dependent')
+            .order_by('-updated_at')
+        )
+        wishlist_by_person = {}
+        for wishlist in candidate_lists:
+            person = wishlist.dependent or wishlist.owner
+            if person.id in person_ids and person.id not in wishlist_by_person:
+                wishlist_by_person[person.id] = wishlist.id
+        for entry in upcoming:
+            entry['wishlist_id'] = wishlist_by_person.get(entry['user'].id)
+
+    return upcoming
+
+
 def home(request):
     # Only show wishlists if user is authenticated
     wishlists_grouped = {}
     current_grouping = 'house'
     grouping_options = []
+    upcoming_birthdays = []
 
     if request.user.is_authenticated:
         # Prompt user to add birthday if missing
@@ -948,7 +1011,6 @@ def home(request):
         else:
             current_grouping = request.session.get('wishlist_grouping')
             if not current_grouping or current_grouping not in strategies:
-                from datetime import date
                 if date.today().month in (11, 12):
                     current_grouping = 'christmas_exchange'
                 else:
@@ -967,6 +1029,9 @@ def home(request):
         # Sort the dictionary keys to have a predictable display order
         wishlists_grouped = dict(sorted(wishlists_grouped.items(), key=lambda item: str(item[0])))
 
+        # "What's coming up": next birthdays across all users (incl. managed accounts)
+        upcoming_birthdays = get_upcoming_birthdays(limit=5)
+
         # Check if logged in user needs to select a scraped page
         show_scraped_page_prompt = False
         if not request.user.scraped_page_selected:
@@ -981,6 +1046,7 @@ def home(request):
         'current_grouping': current_grouping,
         'grouping_options': grouping_options,
         'show_scraped_page_prompt': show_scraped_page_prompt,
+        'upcoming_birthdays': upcoming_birthdays,
     }
     return render(request, 'gift/home.html', context)
 

--- a/tests/api/test_upcoming_birthdays.py
+++ b/tests/api/test_upcoming_birthdays.py
@@ -1,0 +1,135 @@
+"""Tests for the 'Upcoming birthdays' section on the home page."""
+from datetime import date, timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from gift.models import WishList
+
+User = get_user_model()
+
+
+def make_birthday(days_from_today):
+    """Return a birthday whose next occurrence is `days_from_today` days from today."""
+    target = date.today() + timedelta(days=days_from_today)
+    if (target.month, target.day) == (2, 29):
+        # Feb 29 birthdays are observed on Feb 28 in non-leap years; nudge the
+        # target so day offsets stay exact in tests.
+        target += timedelta(days=1)
+    return date(1992, target.month, target.day)  # 1992 is a leap year
+
+
+@pytest.mark.unit
+class TestUpcomingBirthdays:
+    def test_section_hidden_when_no_birthdays(self, authenticated_user):
+        """No users with a birthday set -> the section is not rendered at all."""
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        assert 'Upcoming Birthdays' not in response.content.decode()
+        assert list(response.context['upcoming_birthdays']) == []
+
+    def test_users_without_birthdays_excluded(self, authenticated_user, other_user):
+        """Only users with a birthday set appear in the section."""
+        User.objects.create_user(
+            username='hasbday', email='hasbday@example.com', birthday=make_birthday(10)
+        )
+
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        entries = response.context['upcoming_birthdays']
+        assert [entry['user'].username for entry in entries] == ['hasbday']
+
+    def test_ordering_wraps_year_boundary(self, authenticated_user):
+        """A birthday that just passed goes to the back of the queue (next year),
+        behind a birthday coming up in a few days — not sorted by raw month/day."""
+        User.objects.create_user(
+            username='past-bday', email='past@example.com', birthday=make_birthday(-1)
+        )
+        User.objects.create_user(
+            username='soon-bday', email='soon@example.com', birthday=make_birthday(10)
+        )
+
+        response = authenticated_user.get('/')
+        entries = response.context['upcoming_birthdays']
+        assert [entry['user'].username for entry in entries] == ['soon-bday', 'past-bday']
+        assert entries[0]['days_until'] == 10
+        assert entries[1]['days_until'] > 300
+
+    def test_limit_of_five(self, authenticated_user):
+        """At most 5 upcoming birthdays are shown."""
+        for i in range(1, 8):
+            User.objects.create_user(
+                username=f'bday{i}',
+                email=f'bday{i}@example.com',
+                birthday=make_birthday(i * 5),
+            )
+
+        response = authenticated_user.get('/')
+        entries = response.context['upcoming_birthdays']
+        assert [entry['user'].username for entry in entries] == [
+            'bday1',
+            'bday2',
+            'bday3',
+            'bday4',
+            'bday5',
+        ]
+
+    def test_birthday_today_is_upcoming(self, authenticated_user):
+        """A birthday today counts as upcoming (days_until=0) and is flagged as today."""
+        birthday = make_birthday(0)
+        User.objects.create_user(
+            username='todaybday', email='today@example.com', birthday=birthday
+        )
+
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'todaybday' in content
+        assert 'today!' in content
+        assert f"{birthday.strftime('%b')} {birthday.day}" in content
+        entries = response.context['upcoming_birthdays']
+        assert entries[0]['days_until'] == 0
+        assert entries[0]['turning_age'] == date.today().year - 1992
+
+    def test_name_links_to_most_recently_updated_wishlist(self, authenticated_user):
+        """The person's name links to their most recently updated wishlist."""
+        person = User.objects.create_user(
+            username='linkedbday', email='linked@example.com', birthday=make_birthday(7)
+        )
+        old_list = WishList.objects.create(owner=person, title='Old List')
+        new_list = WishList.objects.create(owner=person, title='New List')
+        WishList.objects.filter(pk=old_list.pk).update(
+            updated_at=timezone.now() - timedelta(days=10)
+        )
+
+        response = authenticated_user.get('/')
+        entries = response.context['upcoming_birthdays']
+        assert entries[0]['wishlist_id'] == new_list.id
+        assert f'/wishlist/{new_list.id}/' in response.content.decode()
+
+    def test_no_wishlist_means_no_link(self, authenticated_user):
+        """A person without any wishlist still shows up, just without a link."""
+        User.objects.create_user(
+            username='nolistbday', email='nolist@example.com', birthday=make_birthday(7)
+        )
+
+        response = authenticated_user.get('/')
+        entries = response.context['upcoming_birthdays']
+        assert entries[0]['wishlist_id'] is None
+        assert 'nolistbday' in response.content.decode()
+
+    def test_wishlist_link_follows_list_person_convention(self, authenticated_user, user):
+        """A managed kid's list (owner=parent, dependent=kid) belongs to the kid:
+        the kid's birthday links to it, the parent's birthday does not."""
+        kid = User.objects.create_user(
+            username='kidbday', email='kid@example.com', birthday=make_birthday(7)
+        )
+        user.birthday = make_birthday(3)
+        user.save()
+        kid_list = WishList.objects.create(owner=user, dependent=kid, title='Kid List')
+
+        response = authenticated_user.get('/')
+        entries = {e['user'].username: e for e in response.context['upcoming_birthdays']}
+        assert entries['kidbday']['wishlist_id'] == kid_list.id
+        assert entries['testuser']['wishlist_id'] is None


### PR DESCRIPTION
Closes #75.

Adds an **Upcoming birthdays** section to the home page (below the grouping selector, above the wishlist groups):

- Next 5 birthdays across all users with a birthday set — managed/kid accounts are WikiUser rows, so they're included automatically.
- Ordered by days until next occurrence with correct year wraparound (a Dec 30 birthday outranks Jan 2 on Dec 28); today's birthday shows "today! 🎉".
- Each row: name, birthday ("Dec 30"), "turns N", and a link to that person's most recently updated wishlist (dependent-or-owner convention matches the directory). Plain row when the person has no list.
- Hidden entirely when no birthdays are set. Feb 29 birthdays are observed on Feb 28 in non-leap years (documented in code).
- Purely additive: reuses existing `wl-*` classes, zero CSS changes, no changes to the existing grouping logic.

Tests: +8 (`tests/api/test_upcoming_birthdays.py`) — hidden-when-empty, no-birthday users excluded, year-boundary ordering, limit of 5, today handling, wishlist link target, no-link fallback, dependent-vs-owner convention. Full suite 76 passed; ruff clean.