### PR TITLE
feat: collapsible groups on the home page (+ expand/collapse all)

### DIFF
--- a/gift/static/css/custom.css
+++ b/gift/static/css/custom.css
@@ -299,6 +299,25 @@ label { font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bo
   border-radius: 4px; padding: 1px 6px;
 }
 
+/* Collapsible group sections (home page) — the whole header row is the toggle */
+.wl-family-header.wl-collapse-toggle {
+  width: 100%;
+  background: none; border: none;
+  border-bottom: 1px solid var(--border);
+  border-radius: 4px 4px 0 0;
+  padding: 10px 4px;
+  font-family: inherit;
+  cursor: pointer; text-align: left;
+}
+.wl-family-header.wl-collapse-toggle:hover { background: var(--bg-subtle); }
+.wl-family-header.wl-collapse-toggle:focus-visible {
+  outline: 2px solid var(--brand); outline-offset: 1px;
+}
+.wl-header-meta { display: inline-flex; align-items: center; gap: 8px; }
+.wl-chevron { color: var(--text-muted); flex-shrink: 0; transition: transform 150ms ease; }
+.wl-collapse-toggle[aria-expanded="false"] .wl-chevron { transform: rotate(-90deg); }
+.wl-section-body[hidden] { display: none; }
+
 /* Wishlist list row */
 .wl-list-row {
   background: var(--bg-surface); border: 1px solid var(--border);

--- a/gift/templates/gift/home.html
+++ b/gift/templates/gift/home.html
@@ -48,6 +48,59 @@
       </div>
     </div>
 
+    {% if upcoming_birthdays %}
+    <div class="wl-family-section">
+
+      <div class="wl-family-header">
+        <span class="wl-family-label">🎂 Upcoming Birthdays</span>
+        <span class="wl-count-badge">{{ upcoming_birthdays|length }}</span>
+      </div>
+
+      <div>
+        {% for entry in upcoming_birthdays %}
+          {% if entry.wishlist_id %}
+          <a class="wl-list-row" href="{% url 'gift:wishlist_detail' entry.wishlist_id %}">
+          {% else %}
+          <div class="wl-list-row">
+          {% endif %}
+
+            <div class="wl-list-row-info">
+              <div class="wl-list-avatar">
+                {% if entry.user.first_name %}
+                  {{ entry.user.first_name|slice:":1"|upper }}{{ entry.user.last_name|slice:":1"|upper }}
+                {% else %}
+                  {{ entry.user.username|slice:":2"|upper }}
+                {% endif %}
+              </div>
+              <div>
+                <div class="wl-list-title">{{ entry.user.get_full_name|default:entry.user.username }}</div>
+                <div class="wl-list-birthday">{{ entry.user.birthday|date:"M j" }} · turns {{ entry.turning_age }}</div>
+              </div>
+            </div>
+
+            <div class="wl-list-row-right">
+              <span class="wl-list-meta">{% if entry.days_until == 0 %}today! 🎉{% else %}in {{ entry.days_until }} day{{ entry.days_until|pluralize }}{% endif %}</span>
+              {% if entry.wishlist_id %}
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2"
+                   stroke-linecap="round" stroke-linejoin="round"
+                   style="color:var(--text-muted);flex-shrink:0;">
+                <polyline points="9 18 15 12 9 6"/>
+              </svg>
+              {% endif %}
+            </div>
+
+          {% if entry.wishlist_id %}
+          </a>
+          {% else %}
+          </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+
+    </div>
+    {% endif %}
+
     {% for group_name, wishlists in wishlists_grouped.items %}
     <div class="wl-family-section">
 

--- a/gift/templates/gift/home.html
+++ b/gift/templates/gift/home.html
@@ -20,7 +20,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="wl-page">
+<div class="wl-page" data-grouping="{{ current_grouping }}">
 
   {% if request.user.is_authenticated %}
 
@@ -35,7 +35,7 @@
         <h1 class="wl-page-title">Wishlists</h1>
         <p class="wl-page-subtitle">Browse by household</p>
         
-        <div class="grouping-controls" style="margin-top: 16px;">
+        <div class="grouping-controls" style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-top: 16px;">
           <form action="" method="get" style="display: flex; align-items: center; gap: 8px;">
             <label for="group_by" style="color: var(--text-muted); font-size: 14px;">Group By:</label>
             <select name="group_by" id="group_by" class="btn btn-outline-secondary" onchange="this.form.submit()" style="padding: 6px 30px 6px 12px; height: 36px; border-radius: 6px; font-size: 13px; font-weight: 500; appearance: none; background: url('data:image/svg+xml;utf8,<svg fill=%22%232a2622%22 viewBox=%220 0 24 24%22 width=%2216%22 height=%2216%22 xmlns=%22http://www.w3.org/2000/svg%22><path d=%22M7 10l5 5 5-5z%22/></svg>') no-repeat right 8px center; cursor: pointer;">
@@ -44,19 +44,30 @@
               {% endfor %}
             </select>
           </form>
+          <div class="wl-bulk-toggle" style="display: flex; gap: 6px;">
+            <button type="button" id="wl-expand-all" class="btn btn-outline-secondary btn-sm">Expand all</button>
+            <button type="button" id="wl-collapse-all" class="btn btn-outline-secondary btn-sm">Collapse all</button>
+          </div>
         </div>
       </div>
     </div>
 
     {% if upcoming_birthdays %}
-    <div class="wl-family-section">
+    <div class="wl-family-section" data-group-label="Upcoming Birthdays">
 
-      <div class="wl-family-header">
+      <button type="button" class="wl-family-header wl-collapse-toggle" aria-expanded="true" aria-controls="wl-group-body-birthdays">
         <span class="wl-family-label">🎂 Upcoming Birthdays</span>
-        <span class="wl-count-badge">{{ upcoming_birthdays|length }}</span>
-      </div>
+        <span class="wl-header-meta">
+          <span class="wl-count-badge">{{ upcoming_birthdays|length }}</span>
+          <svg class="wl-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2"
+               stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="6 9 12 15 18 9"/>
+          </svg>
+        </span>
+      </button>
 
-      <div>
+      <div class="wl-section-body" id="wl-group-body-birthdays">
         {% for entry in upcoming_birthdays %}
           {% if entry.wishlist_id %}
           <a class="wl-list-row" href="{% url 'gift:wishlist_detail' entry.wishlist_id %}">
@@ -102,14 +113,21 @@
     {% endif %}
 
     {% for group_name, wishlists in wishlists_grouped.items %}
-    <div class="wl-family-section">
+    <div class="wl-family-section" data-group-label="{{ group_name }}">
 
-      <div class="wl-family-header">
+      <button type="button" class="wl-family-header wl-collapse-toggle" aria-expanded="true" aria-controls="wl-group-body-{{ forloop.counter }}">
         <span class="wl-family-label">{{ group_name }}</span>
-        <span class="wl-count-badge">{{ wishlists|length }}</span>
-      </div>
+        <span class="wl-header-meta">
+          <span class="wl-count-badge">{{ wishlists|length }}</span>
+          <svg class="wl-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2"
+               stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="6 9 12 15 18 9"/>
+          </svg>
+        </span>
+      </button>
 
-      <div>
+      <div class="wl-section-body" id="wl-group-body-{{ forloop.counter }}">
         {% for wishlist in wishlists %}
         <a class="wl-list-row" href="{% url 'gift:wishlist_detail' wishlist.id %}">
 
@@ -163,6 +181,85 @@
     {% empty %}
     <p style="color:var(--text-muted);margin-top:32px;">No wishlists available yet.</p>
     {% endfor %}
+
+    <script>
+    (function () {
+      'use strict';
+
+      // Collapsible wishlist groups. State is persisted per grouping mode +
+      // group label so switching "Group By" (a server round-trip) restores
+      // each grouping's own collapsed sections. Default with no stored
+      // state is expanded.
+      var STORAGE_PREFIX = 'giftwiki:collapsed:';
+      var page = document.querySelector('.wl-page[data-grouping]');
+      var toggles = Array.prototype.slice.call(document.querySelectorAll('.wl-collapse-toggle'));
+      if (!page || toggles.length === 0) {
+        return;
+      }
+      var grouping = page.getAttribute('data-grouping') || 'house';
+
+      function storageKey(section) {
+        return STORAGE_PREFIX + grouping + ':' + (section.getAttribute('data-group-label') || '');
+      }
+
+      function readCollapsed(section) {
+        try {
+          return window.localStorage.getItem(storageKey(section)) === '1';
+        } catch (e) {
+          return false;  // localStorage unavailable (e.g. private mode) — default expanded
+        }
+      }
+
+      function writeCollapsed(section, collapsed) {
+        try {
+          window.localStorage.setItem(storageKey(section), collapsed ? '1' : '0');
+        } catch (e) {
+          // Ignore: collapsing still works in-memory for this page view.
+        }
+      }
+
+      function applyState(toggle, collapsed) {
+        var body = document.getElementById(toggle.getAttribute('aria-controls'));
+        toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+        if (body) {
+          body.hidden = collapsed;
+        }
+      }
+
+      function setCollapsed(toggle, collapsed) {
+        applyState(toggle, collapsed);
+        var section = toggle.closest('.wl-family-section');
+        if (section) {
+          writeCollapsed(section, collapsed);
+        }
+      }
+
+      toggles.forEach(function (toggle) {
+        var section = toggle.closest('.wl-family-section');
+        if (section && readCollapsed(section)) {
+          applyState(toggle, true);
+        }
+        toggle.addEventListener('click', function () {
+          setCollapsed(toggle, toggle.getAttribute('aria-expanded') !== 'false');
+        });
+      });
+
+      function setAll(collapsed) {
+        toggles.forEach(function (toggle) {
+          setCollapsed(toggle, collapsed);
+        });
+      }
+
+      var expandAll = document.getElementById('wl-expand-all');
+      var collapseAll = document.getElementById('wl-collapse-all');
+      if (expandAll) {
+        expandAll.addEventListener('click', function () { setAll(false); });
+      }
+      if (collapseAll) {
+        collapseAll.addEventListener('click', function () { setAll(true); });
+      }
+    })();
+    </script>
 
   {% else %}
 

--- a/gift/views.py
+++ b/gift/views.py
@@ -3,6 +3,7 @@ import logging
 import secrets
 import string
 from collections import defaultdict
+from datetime import date
 
 from django.conf import settings
 from django.contrib import messages
@@ -915,11 +916,73 @@ def get_grouping_strategies(seasons, request_user):
 
     return strategies
 
+
+def get_upcoming_birthdays(limit=5):
+    """
+    Return the next `limit` upcoming birthdays across all users with a birthday set
+    (managed/kid accounts are WikiUser rows, so they're included automatically),
+    ordered by days until the next occurrence. Today's birthday counts as upcoming
+    (days_until=0). Each entry is a dict with 'user', 'days_until', 'turning_age'
+    and 'wishlist_id' (None when the person has no wishlist to link to).
+    """
+    today = date.today()
+
+    def next_occurrence(birthday):
+        try:
+            next_birthday = birthday.replace(year=today.year)
+        except ValueError:
+            # Feb 29 birthdays are observed on Feb 28 in non-leap years
+            next_birthday = birthday.replace(year=today.year, day=28)
+        if next_birthday < today:
+            try:
+                next_birthday = birthday.replace(year=today.year + 1)
+            except ValueError:
+                next_birthday = birthday.replace(year=today.year + 1, day=28)
+        return next_birthday
+
+    upcoming = []
+    for user in User.objects.filter(birthday__isnull=False):
+        next_birthday = next_occurrence(user.birthday)
+        upcoming.append(
+            {
+                'user': user,
+                'days_until': (next_birthday - today).days,
+                'turning_age': next_birthday.year - user.birthday.year,
+                'wishlist_id': None,
+            }
+        )
+
+    upcoming.sort(key=lambda entry: (entry['days_until'], entry['user'].username))
+    upcoming = upcoming[:limit]
+
+    # Link each person to their most recently updated wishlist, using the same
+    # "person of the list" convention as the directory (dependent, else owner).
+    person_ids = {entry['user'].id for entry in upcoming}
+    if person_ids:
+        candidate_lists = (
+            WishList.objects.filter(
+                models.Q(owner_id__in=person_ids) | models.Q(dependent_id__in=person_ids)
+            )
+            .select_related('owner', 'dependent')
+            .order_by('-updated_at')
+        )
+        wishlist_by_person = {}
+        for wishlist in candidate_lists:
+            person = wishlist.dependent or wishlist.owner
+            if person.id in person_ids and person.id not in wishlist_by_person:
+                wishlist_by_person[person.id] = wishlist.id
+        for entry in upcoming:
+            entry['wishlist_id'] = wishlist_by_person.get(entry['user'].id)
+
+    return upcoming
+
+
 def home(request):
     # Only show wishlists if user is authenticated
     wishlists_grouped = {}
     current_grouping = 'house'
     grouping_options = []
+    upcoming_birthdays = []
 
     if request.user.is_authenticated:
         # Prompt user to add birthday if missing
@@ -948,7 +1011,6 @@ def home(request):
         else:
             current_grouping = request.session.get('wishlist_grouping')
             if not current_grouping or current_grouping not in strategies:
-                from datetime import date
                 if date.today().month in (11, 12):
                     current_grouping = 'christmas_exchange'
                 else:
@@ -967,6 +1029,9 @@ def home(request):
         # Sort the dictionary keys to have a predictable display order
         wishlists_grouped = dict(sorted(wishlists_grouped.items(), key=lambda item: str(item[0])))
 
+        # "What's coming up": next birthdays across all users (incl. managed accounts)
+        upcoming_birthdays = get_upcoming_birthdays(limit=5)
+
         # Check if logged in user needs to select a scraped page
         show_scraped_page_prompt = False
         if not request.user.scraped_page_selected:
@@ -981,6 +1046,7 @@ def home(request):
         'current_grouping': current_grouping,
         'grouping_options': grouping_options,
         'show_scraped_page_prompt': show_scraped_page_prompt,
+        'upcoming_birthdays': upcoming_birthdays,
     }
     return render(request, 'gift/home.html', context)
 

--- a/tests/api/test_collapsible_groups.py
+++ b/tests/api/test_collapsible_groups.py
@@ -1,0 +1,97 @@
+"""Tests for the collapsible wishlist groups on the home page (issue #86).
+
+JS behavior itself isn't unit-tested — these assert the server-rendered
+markup/contracts the JS hooks into: toggle buttons, aria wiring, bulk
+controls, and the data attributes used for localStorage persistence.
+"""
+import re
+from datetime import date
+
+import pytest
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+def birthday_today():
+    """A birthday whose next occurrence is today (1992 is a leap year, so any
+    month/day combo — including Feb 29 — is a valid date)."""
+    today = date.today()
+    return date(1992, today.month, today.day)
+
+
+@pytest.mark.unit
+class TestCollapsibleGroups:
+    def test_expand_collapse_all_controls_rendered(self, authenticated_user, wishlist):
+        """Expand all / Collapse all buttons sit next to the grouping selector."""
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'id="wl-expand-all"' in content
+        assert 'id="wl-collapse-all"' in content
+        assert re.search(
+            r'<button type="button" id="wl-expand-all" class="btn btn-outline-secondary btn-sm">',
+            content,
+        )
+        assert re.search(
+            r'<button type="button" id="wl-collapse-all" class="btn btn-outline-secondary btn-sm">',
+            content,
+        )
+
+    def test_group_header_is_accessible_toggle_button(self, authenticated_user, wishlist):
+        """Each group header is a real <button> with aria-expanded/aria-controls
+        wired to the section body, and keeps the count badge."""
+        response = authenticated_user.get('/?group_by=house')
+        content = response.content.decode()
+        assert (
+            '<button type="button" class="wl-family-header wl-collapse-toggle" '
+            'aria-expanded="true" aria-controls="wl-group-body-1">' in content
+        )
+        assert '<div class="wl-section-body" id="wl-group-body-1">' in content
+        assert 'wl-count-badge' in content
+        assert 'wl-chevron' in content
+
+    def test_every_aria_controls_has_matching_body_id(self, authenticated_user, wishlist):
+        """No toggle points at a missing section body."""
+        User.objects.create_user(username='bday', email='bday@example.com', birthday=birthday_today())
+        response = authenticated_user.get('/?group_by=house')
+        content = response.content.decode()
+        controls = re.findall(r'aria-controls="([^"]+)"', content)
+        assert len(controls) >= 2  # birthdays section + at least one group
+        for target in controls:
+            assert f'id="{target}"' in content
+
+    def test_grouping_mode_exposed_to_js(self, authenticated_user, wishlist):
+        """The current grouping mode is rendered as a data attribute so the JS
+        can scope localStorage keys per grouping."""
+        response = authenticated_user.get('/?group_by=house')
+        assert 'data-grouping="house"' in response.content.decode()
+
+        response = authenticated_user.get('/?group_by=alpha')
+        assert 'data-grouping="alpha"' in response.content.decode()
+
+    def test_group_label_exposed_to_js(self, authenticated_user, wishlist):
+        """Each section carries its group label for the localStorage key scheme."""
+        response = authenticated_user.get('/?group_by=house')
+        assert 'data-group-label="Test Family"' in response.content.decode()
+
+        response = authenticated_user.get('/?group_by=alpha')
+        assert 'data-group-label="T"' in response.content.decode()
+
+    def test_upcoming_birthdays_section_is_collapsible(self, authenticated_user):
+        """The Upcoming birthdays section shares the group markup and gets the
+        same toggle treatment."""
+        User.objects.create_user(username='bday', email='bday@example.com', birthday=birthday_today())
+        response = authenticated_user.get('/')
+        content = response.content.decode()
+        assert 'data-group-label="Upcoming Birthdays"' in content
+        assert 'aria-controls="wl-group-body-birthdays"' in content
+        assert '<div class="wl-section-body" id="wl-group-body-birthdays">' in content
+
+    def test_no_toggle_markup_for_anonymous_visitors(self, client, db):
+        """Anonymous visitors get the sign-in page — no collapse controls/JS."""
+        response = client.get('/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'wl-collapse-toggle' not in content
+        assert 'wl-expand-all' not in content

--- a/tests/api/test_upcoming_birthdays.py
+++ b/tests/api/test_upcoming_birthdays.py
@@ -1,0 +1,135 @@
+"""Tests for the 'Upcoming birthdays' section on the home page."""
+from datetime import date, timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from gift.models import WishList
+
+User = get_user_model()
+
+
+def make_birthday(days_from_today):
+    """Return a birthday whose next occurrence is `days_from_today` days from today."""
+    target = date.today() + timedelta(days=days_from_today)
+    if (target.month, target.day) == (2, 29):
+        # Feb 29 birthdays are observed on Feb 28 in non-leap years; nudge the
+        # target so day offsets stay exact in tests.
+        target += timedelta(days=1)
+    return date(1992, target.month, target.day)  # 1992 is a leap year
+
+
+@pytest.mark.unit
+class TestUpcomingBirthdays:
+    def test_section_hidden_when_no_birthdays(self, authenticated_user):
+        """No users with a birthday set -> the section is not rendered at all."""
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        assert 'Upcoming Birthdays' not in response.content.decode()
+        assert list(response.context['upcoming_birthdays']) == []
+
+    def test_users_without_birthdays_excluded(self, authenticated_user, other_user):
+        """Only users with a birthday set appear in the section."""
+        User.objects.create_user(
+            username='hasbday', email='hasbday@example.com', birthday=make_birthday(10)
+        )
+
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        entries = response.context['upcoming_birthdays']
+        assert [entry['user'].username for entry in entries] == ['hasbday']
+
+    def test_ordering_wraps_year_boundary(self, authenticated_user):
+        """A birthday that just passed goes to the back of the queue (next year),
+        behind a birthday coming up in a few days — not sorted by raw month/day."""
+        User.objects.create_user(
+            username='past-bday', email='past@example.com', birthday=make_birthday(-1)
+        )
+        User.objects.create_user(
+            username='soon-bday', email='soon@example.com', birthday=make_birthday(10)
+        )
+
+        response = authenticated_user.get('/')
+        entries = response.context['upcoming_birthdays']
+        assert [entry['user'].username for entry in entries] == ['soon-bday', 'past-bday']
+        assert entries[0]['days_until'] == 10
+        assert entries[1]['days_until'] > 300
+
+    def test_limit_of_five(self, authenticated_user):
+        """At most 5 upcoming birthdays are shown."""
+        for i in range(1, 8):
+            User.objects.create_user(
+                username=f'bday{i}',
+                email=f'bday{i}@example.com',
+                birthday=make_birthday(i * 5),
+            )
+
+        response = authenticated_user.get('/')
+        entries = response.context['upcoming_birthdays']
+        assert [entry['user'].username for entry in entries] == [
+            'bday1',
+            'bday2',
+            'bday3',
+            'bday4',
+            'bday5',
+        ]
+
+    def test_birthday_today_is_upcoming(self, authenticated_user):
+        """A birthday today counts as upcoming (days_until=0) and is flagged as today."""
+        birthday = make_birthday(0)
+        User.objects.create_user(
+            username='todaybday', email='today@example.com', birthday=birthday
+        )
+
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'todaybday' in content
+        assert 'today!' in content
+        assert f"{birthday.strftime('%b')} {birthday.day}" in content
+        entries = response.context['upcoming_birthdays']
+        assert entries[0]['days_until'] == 0
+        assert entries[0]['turning_age'] == date.today().year - 1992
+
+    def test_name_links_to_most_recently_updated_wishlist(self, authenticated_user):
+        """The person's name links to their most recently updated wishlist."""
+        person = User.objects.create_user(
+            username='linkedbday', email='linked@example.com', birthday=make_birthday(7)
+        )
+        old_list = WishList.objects.create(owner=person, title='Old List')
+        new_list = WishList.objects.create(owner=person, title='New List')
+        WishList.objects.filter(pk=old_list.pk).update(
+            updated_at=timezone.now() - timedelta(days=10)
+        )
+
+        response = authenticated_user.get('/')
+        entries = response.context['upcoming_birthdays']
+        assert entries[0]['wishlist_id'] == new_list.id
+        assert f'/wishlist/{new_list.id}/' in response.content.decode()
+
+    def test_no_wishlist_means_no_link(self, authenticated_user):
+        """A person without any wishlist still shows up, just without a link."""
+        User.objects.create_user(
+            username='nolistbday', email='nolist@example.com', birthday=make_birthday(7)
+        )
+
+        response = authenticated_user.get('/')
+        entries = response.context['upcoming_birthdays']
+        assert entries[0]['wishlist_id'] is None
+        assert 'nolistbday' in response.content.decode()
+
+    def test_wishlist_link_follows_list_person_convention(self, authenticated_user, user):
+        """A managed kid's list (owner=parent, dependent=kid) belongs to the kid:
+        the kid's birthday links to it, the parent's birthday does not."""
+        kid = User.objects.create_user(
+            username='kidbday', email='kid@example.com', birthday=make_birthday(7)
+        )
+        user.birthday = make_birthday(3)
+        user.save()
+        kid_list = WishList.objects.create(owner=user, dependent=kid, title='Kid List')
+
+        response = authenticated_user.get('/')
+        entries = {e['user'].username: e for e in response.context['upcoming_birthdays']}
+        assert entries['kidbday']['wishlist_id'] == kid_list.id
+        assert entries['testuser']['wishlist_id'] is None


### PR DESCRIPTION
Closes #86. **Contains the #75 birthdays commits until #83 merges** (branched off `feat/upcoming-birthdays` so both features ride to dev together); the diff shrinks to just this feature once #83 is in.

- Every home-page group section — wishlist groups in all four grouping modes **and** Upcoming Birthdays — gets a full-width header tap target that collapses/expands its items, with a rotating chevron. Real `<button>` + `aria-expanded`/`aria-controls`, keyboard-operable.
- **Expand all** / **Collapse all** buttons beside the Group By selector (wrap below it on narrow screens).
- Collapsed state persists in `localStorage`, keyed per grouping mode + group label (`giftwiki:collapsed:<grouping>:<label>`), so each grouping restores its own tidy layout after the server-side regroup. Default stays expanded; private-mode degrades to in-memory only.
- Purely client-side vanilla JS (inlined in `home.html` following the existing precedent), no changes to grouping logic.

Tests: +7 (`tests/api/test_collapsible_groups.py`) — bulk buttons render, header toggle contract (`aria-expanded` ↔ matching body `id`), `data-grouping` follows `?group_by=`, birthdays section collapsible, anonymous visitors unaffected. Full suite 83 passed; ruff clean; rendered-page tag-balance check via html.parser.