### PR TITLE
fix: template comment leaking into every home-page card

### DIFF
--- a/gift/templates/gift/home.html
+++ b/gift/templates/gift/home.html
@@ -158,8 +158,7 @@
           </div>
 
           <div class="wl-list-row-right">
-            {# card_item_count is computed in the home view: active items only,
-               excluding surprise items when the viewer owns the list. #}
+            {# card_item_count comes from the home view: active items only, excluding surprises for the owner. #}
             <span class="wl-list-meta">{{ wishlist.card_item_count }} items</span>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
                  stroke="currentColor" stroke-width="2"

--- a/tests/api/test_template_comments.py
+++ b/tests/api/test_template_comments.py
@@ -1,0 +1,23 @@
+"""Regression test: multi-line {# #} comments are NOT valid Django template
+comments (they only work on a single line) and leak into rendered HTML.
+Keep rendered pages free of raw template-comment markers."""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestTemplateCommentLeak:
+    def test_home_page_has_no_template_comment_markers(self, authenticated_user, wishlist):
+        response = authenticated_user.get('/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert '{#' not in content
+        assert '#}' not in content
+
+    def test_wishlist_detail_has_no_template_comment_markers(self, authenticated_user, wishlist):
+        response = authenticated_user.get(f'/wishlist/{wishlist.id}/')
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert '{#' not in content
+        assert '#}' not in content


### PR DESCRIPTION
The multi-line `{# ... #}` comment above the card item count (added in #89) rendered as visible text inside **every wishlist card** on the home page — Django only treats `{# #}` as a comment on a single line. Reproduced against the prod data: 21 leaked markers on the home page.

Fix: collapsed to a single-line comment. Also swept all templates — this was the only multi-line `{# #}` comment in the codebase.

Tests: +2 (`tests/api/test_template_comments.py`) asserting home and wishlist detail render without `{#/#}` markers, so this can't come back. Full suite 139 passed; ruff clean.

This bug is visible on prod — merging deploys the fix there automatically.